### PR TITLE
Solving for cold start in supertrend - setting a default trend value of +1

### DIFF
--- a/pandas_ta/overlap/supertrend.py
+++ b/pandas_ta/overlap/supertrend.py
@@ -18,7 +18,7 @@ def supertrend(high, low, close, length=None, multiplier=None, offset=None, **kw
 
     # Calculate Results
     m = close.size
-    dir_, trend = [0] * m, [0] * m
+    dir_, trend = [1] * m, [0] * m
     long, short = [npNaN] * m, [npNaN] * m
 
     hl2_ = hl2(high, low)
@@ -82,7 +82,9 @@ Sources:
 Calculation:
     Default Inputs:
         length=7, multiplier=3.0
-    
+    Default Direction:
+	Set to +1 or bullish trend at start
+
     MID = multiplier * ATR
     LOWERBAND = HL2 - MID
     UPPERBAND = HL2 + MID


### PR DESCRIPTION
Supertrend needs to be cold-started after the initial set of specified periods (default = 10).

If the initial trend is not set, the high and low value keep on fluctuating and we don't get a definite trend till there is a high-volume day that breaches the high or low value for a day. This is a rare occurrence (especially for low volatility stocks).
This might cause the trend to be set to 0 for over 100 periods in case of a range-bound ticker. 
For weekly data, it might lead to trend not being set for over a year (An issue I faced which caused me to make the change here).

The key problem was that the range fluctuates higher or lower if trend = 0. For trend = +1 and -1, the range is set to max and min respectively. This allows the line to tripped and the trend to change in case of price movement.