### PR TITLE
Change to Variance and Std

### DIFF
--- a/pandas_ta/statistics/stdev.py
+++ b/pandas_ta/statistics/stdev.py
@@ -3,15 +3,16 @@ from numpy import sqrt as npsqrt
 from .variance import variance
 from ..utils import get_offset, verify_series
 
-def stdev(close, length=None, offset=None, **kwargs):
+def stdev(close, length=None, ddof=1, offset=None, **kwargs):
     """Indicator: Standard Deviation"""
     # Validate Arguments
     close = verify_series(close)
     length = int(length) if length and length > 0 else 30
+    ddof = int(ddof) if ddof >= 0 and ddof < length else 1
     offset = get_offset(offset)
 
     # Calculate Result
-    stdev = variance(close=close, length=length).apply(npsqrt)
+    stdev = variance(close=close, length=length, ddof=ddof).apply(npsqrt)
 
     # Offset
     if offset != 0:
@@ -39,6 +40,9 @@ Calculation:
 Args:
     close (pd.Series): Series of 'close's
     length (int): It's period.  Default: 30
+    ddof (int): Delta Degrees of Freedom. 
+                The divisor used in calculations is N - ddof, 
+                where N represents the number of elements. Default: 1 
     offset (int): How many periods to offset the result.  Default: 0
 
 Kwargs:

--- a/pandas_ta/statistics/variance.py
+++ b/pandas_ta/statistics/variance.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 from ..utils import get_offset, verify_series
 
-def variance(close, length=None, offset=None, **kwargs):
+def variance(close, length=None, ddof=1, offset=None, **kwargs):
     """Indicator: Variance"""
     # Validate Arguments
     close = verify_series(close)
     length = int(length) if length and length > 1 else 30
+    ddof = int(ddof) if ddof >= 0 and ddof < length else 1
+
     min_periods = int(kwargs['min_periods']) if 'min_periods' in kwargs and kwargs['min_periods'] is not None else length
     offset = get_offset(offset)
 
     # Calculate Result
-    variance = close.rolling(length, min_periods=min_periods).var()
+    variance = close.rolling(length, min_periods=min_periods).var(ddof)
 
     # Offset
     if offset != 0:
@@ -37,6 +39,9 @@ Calculation:
 Args:
     close (pd.Series): Series of 'close's
     length (int): It's period.  Default: 30
+    ddof (int): Delta Degrees of Freedom. 
+                The divisor used in calculations is N - ddof, 
+                where N represents the number of elements. Default: 1 
     offset (int): How many periods to offset the result.  Default: 0
 
 Kwargs:


### PR DESCRIPTION
When calculation variance we can divide the calculation by N, or by N-1.
When calculating sample variance we divide by N-1 (like in the current code).(https://towardsdatascience.com/why-sample-variance-is-divided-by-n-1-89821b83ef6d)
Sometimes We want to divide by N like the basis formula, to calculate population variance. (https://en.wikipedia.org/wiki/Variance#Discrete_random_variable)
For me its useful to add another parameter that will make it possible to calculate both of then using one function.
Is it useful for you?