### PR TITLE
fix passing incorrect stdev parameter to bbands

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -1312,9 +1312,9 @@ class AnalysisIndicators(BasePandasObject):
         result = atr(high=high, low=low, close=close, length=length, mamode=mamode, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
-    def bbands(self, length=None, stdev=None, mamode=None, offset=None, **kwargs):
+    def bbands(self, length=None, std=None, mamode=None, offset=None, **kwargs):
         close  = self._get_column(kwargs.pop("close", "close"))
-        result = bbands(close=close, length=length, stdev=stdev, mamode=mamode, offset=offset, **kwargs)
+        result = bbands(close=close, length=length, std=std, mamode=mamode, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
     def donchian(self, lower_length=None, upper_length=None, offset=None, **kwargs):


### PR DESCRIPTION
`core.py::bbands` was taking in `stdev` and passing it to `volatility/bbands.py::bbands`, which expected `std`. The parameter got ignored, resulting in only ever creating `_2.0` bband columns.

Not sure which abbreviation you prefer - I saw occurrences of both across the repo. Happy to switch to the other one if you prefer.