### PR TITLE
Setting version regardless

### DIFF
--- a/pandas_ta/__init__.py
+++ b/pandas_ta/__init__.py
@@ -15,8 +15,8 @@ try:
         raise DistributionNotFound
 except DistributionNotFound:
     __version__ = "Please install this project with setup.py"
-else:
-    version = __version__ = _dist.version
+
+version = __version__ = _dist.version
 
 from importlib.util import find_spec
 


### PR DESCRIPTION
Currently, the version is not set if the `try-except` block errors out. 