### PR TITLE
Updated docs reflecting the length default value

### DIFF
--- a/pandas_ta/volatility/bbands.py
+++ b/pandas_ta/volatility/bbands.py
@@ -91,9 +91,9 @@ Calculation:
 
 Args:
     close (pd.Series): Series of 'close's
-    length (int): The short period. Default: 20
+    length (int): The short period. Default: 5
     std (int): The long period. Default: 2
-    mamode (str): Two options: "sma" or "ema". Default: "ema"
+    mamode (str): Two options: "sma" or "ema". Default: "sma"
     offset (int): How many periods to offset the result. Default: 0
 
 Kwargs:


### PR DESCRIPTION
After https://github.com/twopirllc/pandas-ta/commit/fcaf5e90e1af9a05221eb8e0628a99eee256ed9c and https://github.com/twopirllc/pandas-ta/commit/18aacc8eab2ad28962c506e242e3d719c005fe2d, the method documentation regarding the default length and moving average mode parameters became misaligned