### PR TITLE
bugfix Cum. Active Returns with cumprod

### DIFF
--- a/examples/AIExample.ipynb
+++ b/examples/AIExample.ipynb
@@ -1077,7 +1077,7 @@
     }
    ],
    "source": [
-    "asset[\"ACTRET_1\"] = trendy.TS_Trends * asset.PCTRET_1\n",
+    "asset[\"ACTRET_1\"] = trendy.TS_Trends.shift(1) * asset.PCTRET_1\n",
     "asset[[\"PCTRET_1\", \"ACTRET_1\"]].plot(figsize=(16, 3), color=colors(\"GyOr\"), alpha=1, grid=True).axhline(0, color=\"black\")"
    ]
   },

--- a/examples/AIExample.ipynb
+++ b/examples/AIExample.ipynb
@@ -1117,7 +1117,7 @@
     }
    ],
    "source": [
-    "asset[[\"PCTRET_1\", \"ACTRET_1\"]].cumsum().plot(figsize=(16, 3), kind=\"area\", stacked=False, color=colors(\"GyOr\"), title=\"B&H vs. Cum. Active Returns\", alpha=.4, grid=True).axhline(0, color=\"black\")"
+    "((asset[[\"PCTRET_1\", \"ACTRET_1\"]]+1).cumprod()-1).plot(figsize=(16, 3), kind=\"area\", stacked=False, color=colors(\"GyOr\"), title=\"B&H vs. Cum. Active Returns\", alpha=.4, grid=True).axhline(0, color=\"black\")"
    ]
   },
   {


### PR DESCRIPTION
In performance/percent_return.py:
pct_return = close.pct_change(length) # (close / close.shift(length)) - 1
So, when calculate back, it should be:
cum return = (1 + pct_return).cumprod() -1

As the close of today has been used for calculation, we cannot earn the return of today. Our trade decision only earn the return of next day.

BTW, nice example, appreciated for the good job!