### PR TITLE
Allow to use non TA-Lib way of calculating CMO with TA-Lib installed

### DIFF
--- a/pandas_ta/momentum/cmo.py
+++ b/pandas_ta/momentum/cmo.py
@@ -12,11 +12,12 @@ def cmo(close, length=None, scalar=None, drift=None, offset=None, **kwargs):
     close = verify_series(close, length)
     drift = get_drift(drift)
     offset = get_offset(offset)
+    talib_mode = kwargs.pop("talib", True)
 
     if close is None: return
 
     # Calculate Result
-    if Imports["talib"]:
+    if talib_mode and Imports["talib"]:
         from talib import CMO
         cmo = CMO(close, length)
     else:
@@ -24,8 +25,7 @@ def cmo(close, length=None, scalar=None, drift=None, offset=None, **kwargs):
         positive = mom.copy().clip(lower=0)
         negative = mom.copy().clip(upper=0).abs()
 
-        talib = kwargs.pop("talib", True)
-        if talib:
+        if talib_mode:
             pos_ = rma(positive, length)
             neg_ = rma(negative, length)
         else:

--- a/tests/test_indicator_momentum.py
+++ b/tests/test_indicator_momentum.py
@@ -144,6 +144,13 @@ class TestMomentum(TestCase):
             except Exception as ex:
                 error_analysis(result, CORRELATION, ex)
 
+    def test_cmo_no_talib(self):
+        result = pandas_ta.cmo(self.close, talib=False)
+
+        talib_result = tal.CMO(self.close)
+        corr = pandas_ta.utils.df_error_analysis(result, talib_result, col=CORRELATION)
+        self.assertLess(corr, CORRELATION_THRESHOLD)
+
     def test_coppock(self):
         result = pandas_ta.coppock(self.close)
         self.assertIsInstance(result, Series)


### PR DESCRIPTION
So there's a TA-Lib way of calculating CMO which uses RMAs instead of rolling sums. There's even a kwarg switch to use the default method. Unfortunately the switch is ignored when TA-Lib is installed. That's what i'd propose to change. Thanks for your great effort! 