### PR TITLE
Proposed new way to dynamically add and test out indicators without modifying pandas_ta itself

### DIFF
--- a/examples/ni.py
+++ b/examples/ni.py
@@ -73,17 +73,7 @@ Returns:
 
 # - Define a matching class method --------------------------------------------
 
-# NOTE: we need to temporarily use another name for the method than for the 
-# function to avoid a name conflict in this module. But by using the bind 
-# function below we can name it right so that doesn't really matter. 
-# Just remember to rename the method if you at a later stage decide to move it 
-# into the core.py module inside pandas_ta
 def ni_method(self, length=None, offset=None, **kwargs):
     close = self._get_column(kwargs.pop("close", "close"))
     result = ni(close=close, length=length, offset=offset, **kwargs)
     return self._post_process(result, **kwargs)
-
-# - Bind the function to pandas_ta and the method to AnalysisIndicators -------
-
-from pandas_ta.custom import bind
-bind('ni', ni, ni_method)

--- a/examples/ni.py
+++ b/examples/ni.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from pandas_ta.overlap import sma
+from pandas_ta.utils import get_offset, verify_series
+
+# - Standard definition of your custom indicator function (including docs)-
+
+def ni(close, length=None, centered=False, offset=None, **kwargs):
+    """
+    Example indicator ni
+    """
+    # Validate Arguments
+    length = int(length) if length and length > 0 else 20
+    close = verify_series(close, length)
+    offset = get_offset(offset)
+
+    if close is None: return
+
+    # Calculate Result
+    t = int(0.5 * length) + 1
+    ma = sma(close, length)
+
+    ni = close - ma.shift(t)
+    if centered:
+        ni = (close.shift(t) - ma).shift(-t)
+
+    # Offset
+    if offset != 0:
+        ni = ni.shift(offset)
+
+    # Handle fills
+    if "fillna" in kwargs:
+        ni.fillna(kwargs["fillna"], inplace=True)
+    if "fill_method" in kwargs:
+        ni.fillna(method=kwargs["fill_method"], inplace=True)
+
+    # Name and Categorize it
+    ni.name = f"ni_{length}"
+    ni.category = "trend"
+
+    return ni
+
+ni.__doc__ = \
+"""Example indicator (NI)
+
+Is an indicator provided solely as an example
+
+Sources:
+    https://github.com/twopirllc/pandas-ta/issues/264
+
+Calculation:
+    Default Inputs:
+        length=20, centered=False
+    SMA = Simple Moving Average
+    t = int(0.5 * length) + 1
+
+    ni = close.shift(t) - SMA(close, length)
+    if centered:
+        ni = ni.shift(-t)
+
+Args:
+    close (pd.Series): Series of 'close's
+    length (int): It's period. Default: 20
+    centered (bool): Shift the ni back by int(0.5 * length) + 1. Default: False
+    offset (int): How many periods to offset the result. Default: 0
+
+Kwargs:
+    fillna (value, optional): pd.DataFrame.fillna(value)
+    fill_method (value, optional): Type of fill method
+
+Returns:
+    pd.Series: New feature generated.
+"""
+
+# - Define a matching class method --------------------------------------------
+
+# NOTE: we need to temporarily use another name for the method than for the 
+# function to avoid a name conflict in this module. But by using the bind 
+# function below we can name it right so that doesn't really matter. 
+# Just remember to rename the method if you at a later stage decide to move it 
+# into the core.py module inside pandas_ta
+def ni_method(self, length=None, offset=None, **kwargs):
+    close = self._get_column(kwargs.pop("close", "close"))
+    result = ni(close=close, length=length, offset=offset, **kwargs)
+    return self._post_process(result, **kwargs)
+
+# - Bind the function to pandas_ta and the method to AnalysisIndicators -------
+
+from pandas_ta.custom import bind
+bind('ni', ni, ni_method)

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from os.path import dirname, abspath, join
+from glob import glob
+import importlib
+import pandas_ta
+
+def import_dir(dir_path, create_categories=True, verbose=True):
+
+    # ensure that the passed directory exists / is readable
+    if not os.path.exists(dir_path):
+        print(f"[X] Unable to read the directory '{dir_path}'.")
+        return
+   
+    # list the contents of the directory
+    dirs = glob(abspath(join(dir_path, '*')))
+
+    # optionally add any missing category subdirectories
+    if create_categories:
+        for sd in [*pandas_ta.Category]:
+            d = abspath(join(dir_path, sd)
+            if not os.path.exists(d):
+                os.makedirs(directory
+
+    # traverse the directory, importing all modules found there
+    for d in dirs:
+        dirname = os.path.basename(d)
+
+        if dirname not in [*pandas_ta.Category]:
+            print(f"[i] Skipping the sub-directory '{dirname}' since it's not a pandas_ta category.")
+            continue
+
+        for module in glob(abspath(join(dir_path, dirname, '*.py'))):
+            module = os.path.splitext(os.path.basename(module))[0]
+
+            if module in pandas_ta.Category[dirname]:
+                print(f"[X] Skipping the custom module '{module}' since a function with that name already exists in pandas_ta.")
+                continue
+
+            # import the module and add it to the correct category
+            pandas_ta.Category[dirname].append(module)
+            if d not in sys.path:
+                sys.path.append(d) 
+            importlib.import_module(module, d)
+
+            if verbose:
+                print(f"[i] Successfully imported the module '{module}' into category '{dirname}'.")
+
+import_dir.__doc__ = \
+"""
+This method allows you to experiment and develop your own technical analysis
+indicators independantly in a separate local directory of your choice but
+still use them seamlessly together with the existing pandas_ta functions just 
+like if they were part of pandas_ta.
+
+If you at some late point would like to push them into the pandas_ta library
+you can do so very easily by following the step by step instruction here
+https://github.com/twopirllc/pandas-ta/issues/264.
+
+----------------------------------
+
+By default, the 'ta' extension uses lower case column names: open, high,
+low, close, and volume. You can override the defaults by providing the it's
+replacement name when calling the indicator. For example, to call the
+indicator hl2().
+
+With 'default' columns: open, high, low, close, and volume.
+>>> df.ta.hl2()
+>>> df.ta(kind="hl2")
+
+With DataFrame columns: Open, High, Low, Close, and Volume.
+>>> df.ta.hl2(high="High", low="Low")
+>>> df.ta(kind="hl2", high="High", low="Low")
+
+If you do not want to use a DataFrame Extension, just call it normally.
+>>> sma10 = ta.sma(df["Close"]) # Default length=10
+>>> sma50 = ta.sma(df["Close"], length=50)
+>>> ichimoku, span = ta.ichimoku(df["High"], df["Low"], df["Close"])
+
+Args:
+    kind (str, optional): Default: None. Kind is the 'name' of the indicator.
+        It converts kind to lowercase before calling.
+    timed (bool, optional): Default: False. Curious about the execution
+        speed?
+    kwargs: Extension specific modifiers.
+        append (bool, optional): Default: False. When True, it appends the
+        resultant column(s) to the DataFrame.
+
+Returns:
+    Most Indicators will return a Pandas Series. Others like MACD, BBANDS,
+    KC, et al will return a Pandas DataFrame. Ichimoku on the other hand
+    will return two DataFrames, the Ichimoku DataFrame for the known period
+    and a Span DataFrame for the future of the Span values.
+
+Let's get started!
+
+1. Loading the 'ta' module:
+>>> import pandas as pd
+>>> import ta as ta
+
+2. Load some data:
+>>> df = pd.read_csv("AAPL.csv", index_col="date", parse_dates=True)
+
+3. Help!
+3a. General Help:
+>>> help(df.ta)
+>>> df.ta()
+3b. Indicator Help:
+>>> help(ta.apo)
+3c. Indicator Extension Help:
+>>> help(df.ta.apo)
+
+4. Ways of calling an indicator.
+4a. Standard: Calling just the APO indicator without "ta" DataFrame extension.
+>>> ta.apo(df["close"])
+4b. DataFrame Extension: Calling just the APO indicator with "ta" DataFrame extension.
+>>> df.ta.apo()
+4c. DataFrame Extension (kind): Calling APO using 'kind'
+>>> df.ta(kind="apo")
+4d. Strategy:
+>>> df.ta.strategy("All") # Default
+>>> df.ta.strategy(ta.Strategy("My Strat", ta=[{"kind": "apo"}])) # Custom
+
+5. Working with kwargs
+5a. Append the result to the working df.
+>>> df.ta.apo(append=True)
+5b. Timing an indicator.
+>>> apo = df.ta(kind="apo", timed=True)
+>>> print(apo.timed)
+"""

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -10,36 +10,6 @@ import pandas_ta
 import pandas as pd
 from pandas_ta import AnalysisIndicators
 
-def create_dir(dir_path, create_categories=True, verbose=True):
-    """ 
-    Helper function to setup a suitable folder structure for working with 
-    custom indicators.
-
-    Args:
-        dir_path (str): Full path to where you want your indicator tree
-        create_categories (bool): If True create category sub-folders
-        verbose (bool): If True verbose output of results
-    """
-
-    # ensure that the passed directory exists / is readable
-    if not exists(dir_path):
-        os.makedirs(dir_path)
-        if verbose:
-            print(f"[i] Created main directory '{dir_path}'.")
-
-    # list the contents of the directory
-    dirs = glob(abspath(join(dir_path, '*')))
-
-    # optionally add any missing category subdirectories
-    if create_categories:
-        for sd in [*pandas_ta.Category]:
-            d = abspath(join(dir_path, sd))
-            if not exists(d):
-                os.makedirs(d)
-                if verbose:
-                    dirname = basename(d)
-                    print(f"[i] Created an empty sub-directory '{dirname}'.")
-
 def import_dir(dir_path, verbose=True):
 
     # ensure that the passed directory exists / is readable
@@ -108,7 +78,7 @@ If you at some late point would like to push them into the pandas_ta library
 you can do so very easily by following the step by step instruction here
 https://github.com/twopirllc/pandas-ta/issues/264.
 
-Let's get started!
+A brief example of usage:
 
 1. Loading the 'ta' module:
 >>> import pandas as pd
@@ -157,15 +127,14 @@ designated indicators directory like this:
 
 >>> import_dir(my_dir)
 
-If your custom indicator loaded succesfully then it should behave exactly
+If your custom indicator(s) loaded succesfully then it should behave exactly
 like all other native indicators in pandas_ta, including help functions.
 """
 
 def bind(function_name, function, method):
     """ 
     Helper function to bind the function and class method defined in a custom
-    indicator module to the active pandas_ta instance. It is supposed to be
-    invoked last in all custom indicator modules.
+    indicator module to the active pandas_ta instance.
 
     Args:
         function_name (str): The name of the indicator within pandas_ta
@@ -182,11 +151,8 @@ def load_indicator_module(module_name):
     Returns:
         dict: module functions mapping
         {
-            "func1_name": func,
-            "func2_name": func2
-            .
-            .
-            .
+            "func1_name": func1,
+            "func2_name": func2,...
         }
 
     """
@@ -209,12 +175,11 @@ def get_module_functions(module):
         module: python module
 
     Returns:
-        dict: functions mapping for specified python module
-
-            {
-                "func1_name": func1,
-                "func2_name": func2
-            }
+        dict: module functions mapping
+        {
+            "func1_name": func1,
+            "func2_name": func2,...
+        }
 
     """
     module_functions = {}
@@ -224,3 +189,34 @@ def get_module_functions(module):
             module_functions[name] = item
 
     return module_functions
+
+def create_dir(dir_path, create_categories=True, verbose=True):
+    """ 
+    Helper function to setup a suitable folder structure for working with 
+    custom indicators. You only need to call this once whenever you want to
+    setup a new custom indicators folder. 
+
+    Args:
+        dir_path (str): Full path to where you want your indicator tree
+        create_categories (bool): If True create category sub-folders
+        verbose (bool): If True print verbose output of results
+    """
+
+    # ensure that the passed directory exists / is readable
+    if not exists(dir_path):
+        os.makedirs(dir_path)
+        if verbose:
+            print(f"[i] Created main directory '{dir_path}'.")
+
+    # list the contents of the directory
+    dirs = glob(abspath(join(dir_path, '*')))
+
+    # optionally add any missing category subdirectories
+    if create_categories:
+        for sd in [*pandas_ta.Category]:
+            d = abspath(join(dir_path, sd))
+            if not exists(d):
+                os.makedirs(d)
+                if verbose:
+                    dirname = basename(d)
+                    print(f"[i] Created an empty sub-directory '{dirname}'.")

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -67,9 +67,8 @@ def import_dir(dir_path, verbose=True):
             module = splitext(basename(module))[0]
 
             # check that we only load modules not already loaded in pandas_ta 
-            if module in names_already_in_use:
-                print(f"[i] Warning: the custom module '{module}' will replace a module in pandas_ta.")
-                continue
+            if verbose and module in names_already_in_use:
+                print(f"[i] Warning: the custom module '{module}' will replace a module currently loaded in pandas_ta.")
 
             # ensure that the supplied path is included in our python path
             if d not in sys.path:

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -7,6 +7,7 @@ from glob import glob
 import importlib
 import pandas_ta
 import pandas as pd
+from pandas_ta import AnalysisIndicators
 
 def create_dir(dir_path, create_categories=True, verbose=True):
     """ 
@@ -45,10 +46,6 @@ def import_dir(dir_path, verbose=True):
         print(f"[X] Unable to read the directory '{dir_path}'.")
         return
 
-    # obtain a list of all reserved pandas_ta indicator names 
-    df = pd.DataFrame()
-    names_already_in_use = df.ta.indicators(as_list=True)
-
     # list the contents of the directory
     dirs = glob(abspath(join(dir_path, '*')))
 
@@ -65,10 +62,6 @@ def import_dir(dir_path, verbose=True):
         # for each module found in that category (directory)...
         for module in glob(abspath(join(dir_path, dirname, '*.py'))):
             module = splitext(basename(module))[0]
-
-            # check that we only load modules not already loaded in pandas_ta 
-            if verbose and module in names_already_in_use:
-                print(f"[i] Warning: the custom module '{module}' will replace a module currently loaded in pandas_ta.")
 
             # ensure that the supplied path is included in our python path
             if d not in sys.path:
@@ -149,3 +142,17 @@ like all other native indicators in pandas_ta. E.g.
 >>> ni = df.ta(kind="ni", timed=True)
 >>> print(ni.timed)
 """
+
+def bind(function_name, function, method):
+    """ 
+    Helper function to bind the function and class method defined in a custom
+    indicator module to the active pandas_ta instance. It is supposed to be
+    invoked last in all custom indicator modules.
+
+    Args:
+        function_name (str): The name of the indicator within pandas_ta
+        function (fcn): The indicator function
+        method (fcn): The class method corresponding to the passed function
+    """
+    setattr(pandas_ta, function_name, function)
+    setattr(AnalysisIndicators, function_name, method)

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -72,7 +72,7 @@ def import_dir(dir_path, verbose=True):
             pandas_ta.Category[dirname].append(module)
 
             if verbose:
-                print(f"[i] Successfully imported the indicator '{module}' into category '{dirname}'.")
+                print(f"[i] Successfully imported the custom indicator '{module}' into category '{dirname}'.")
 
 import_dir.__doc__ = \
 """

--- a/pandas_ta/custom.py
+++ b/pandas_ta/custom.py
@@ -95,22 +95,33 @@ Let's get started!
 
 1. Loading the 'ta' module:
 >>> import pandas as pd
->>> import ta as ta
+>>> import pandas_ta as ta
 
 2. Create an empty directory on your machine where you want to work with your
 indicators. Invoke pandas_ta.custom.import_dir once to pre-populate it with 
 sub-folders for all available indicator categories, e.g.:
 
->>> ta.custom.create_dir('~/my_indicators')
+>>> import os
+>>> from os.path import abspath, join, expanduser
+>>> from pandas_ta.custom import create_dir, import_dir
+>>> my_dir = abspath(join(expanduser("~"), "my_indicators"))
+>>> create_dir(my_dir)
 
 3. You can now create your own custom indicator e.g. by copying existing 
 ones from pandas_ta core module and modifying them. Each custom indicator 
-should have a unique name and have both a function and a method defined.
+should have a unique name and have both a function and a method defined
+within the module. In essence these modules should look exactly like the
+standard indicators available in categories under the pandas_ta-folder.
+
+The only difference will be an addition of a matching class method that
+will be imported dynamically to the AnalysisIndicators class and a
+call to the utility function that binds the indicator name to pandas_ta.
+
 For an example of the correct structure, look at the example ni.py in the 
 examples folder.
 
-The ni.py indicator is a trend indicator so we drop it into the sub-folder
-named trend. Thus we have a folder structure like this:
+The ni.py indicator is a trend indicator so therefoe we drop it into the 
+sub-folder named trend. Thus we have a folder structure like this:
 
 ~/my_indicators/
 │
@@ -125,22 +136,10 @@ named trend. Thus we have a folder structure like this:
 4. We can now dynamically load all our custom indicators located in our
 designated indicators directory like this:
 
->>> ta.custom.import_dir('~/my_indicators')
+>>> import_dir(my_dir)
 
 If your custom indicator loaded succesfully then it should behave exactly
-like all other native indicators in pandas_ta. E.g.
-
->>> help(ta.ni)
->>> help(df.ta.ni)
->>> df = pd.read_csv("AAPL.csv", index_col="date", parse_dates=True)
->>> ta.ni(df["close"])
->>> df.ta.ni()
->>> df.ta(kind="ni")
->>> df.ta.strategy("All") # Default
->>> df.ta.strategy(ta.Strategy("My Strat", ta=[{"kind": "ni"}])) # Custom
->>> df.ta.ni(append=True)
->>> ni = df.ta(kind="ni", timed=True)
->>> print(ni.timed)
+like all other native indicators in pandas_ta, including help functions.
 """
 
 def bind(function_name, function, method):


### PR DESCRIPTION
Hi KJ, 

Basically this pull-request concerns what I asked about in this closed issue https://github.com/twopirllc/pandas-ta/issues/264

I added a new module custom.py with all required functionality and an example indicator that can be used as a template (the same one used in the issue ni.py). I put ni.py in the examples folder.

The usage is described in the import_dir-function of the custom module.

```
Import a directory of custom indicators into pandas_ta

Args:
    dir_path (str): Full path to your indicator tree
    verbose (bool): If True verbose output of results

This method allows you to experiment and develop your own technical analysis
indicators in a separate local directory of your choice but use them seamlessly 
together with the existing pandas_ta functions just like if they were part of 
pandas_ta.

If you at some late point would like to push them into the pandas_ta library
you can do so very easily by following the step by step instruction here
https://github.com/twopirllc/pandas-ta/issues/264.

Let's get started!

1. Loading the 'ta' module:
>>> import pandas as pd
>>> import pandas_ta as ta

2. Create an empty directory on your machine where you want to work with your
indicators. Invoke pandas_ta.custom.import_dir once to pre-populate it with 
sub-folders for all available indicator categories, e.g.:

>>> import os
>>> from os.path import abspath, join, expanduser
>>> from pandas_ta.custom import create_dir, import_dir
>>> my_dir = abspath(join(expanduser("~"), "my_indicators"))
>>> create_dir(my_dir)

3. You can now create your own custom indicator e.g. by copying existing 
ones from pandas_ta core module and modifying them. Each custom indicator 
should have a unique name and have both a function and a method defined
within the module. In essence these modules should look exactly like the
standard indicators available in categories under the pandas_ta-folder.

The only difference will be an addition of a matching class method that
will be imported dynamically to the AnalysisIndicators class and a
call to the utility function that binds the indicator name to pandas_ta.

For an example of the correct structure, look at the example ni.py in the 
examples folder.

The ni.py indicator is a trend indicator so therefoe we drop it into the 
sub-folder named trend. Thus we have a folder structure like this:

~/my_indicators/
│
├── candles/
.
.
└── trend/
.      └── ni.py
.
└── volume/

4. We can now dynamically load all our custom indicators located in our
designated indicators directory like this:

>>> import_dir(my_dir)

If your custom indicator loaded succesfully then it should behave exactly
like all other native indicators in pandas_ta, including help functions.
```

Kind regards
Urban