### PR TITLE
Add signal line to TSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ of the last bars defined by the length parameter. See ```help(ta.tos_stdevall)``
 * _Increasing_ (**increasing**): New argument ```strict``` checks if the series is continuously increasing over period ```length``` with a faster calculation. Default: ```False```. The ```percent``` argument has also been added with default None. See ```help(ta.increasing)```.
 * _Parabolic Stop and Reverse_ (**psar**): Bug fix and adjustment to match TradingView's ```sar```. New argument ```af0``` to initialize the Acceleration Factor. See ```help(ta.psar)```.
 * _Percentage Price Oscillator_ (**ppo**): Included new argument ```mamode``` as an option. Default is **sma** to match TA Lib. See ```help(ta.ppo)```.
+* _True Strength Index_ (**tsi**): Added ```signal``` argument. See ```help(ta.tsi)```.
 * _Volume Profile_ (**vp**): Calculation improvements. See [Pull Request #320](https://github.com/twopirllc/pandas-ta/pull/320) See ```help(ta.vp)```.
 * _Volume Weighted Moving Average_ (**vwma**): Fixed bug in DataFrame Extension call. See ```help(ta.vwma)```.
 * _Volume Weighted Average Price_ (**vwap**): Added a new parameter called ```anchor```. Default: "D" for "Daily". See [Timeseries Offset Aliases](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases) for additional options. **Requires** the DataFrame index to be a DatetimeIndex. See ```help(ta.vwap)```.

--- a/pandas_ta/momentum/smi.py
+++ b/pandas_ta/momentum/smi.py
@@ -20,8 +20,9 @@ def smi(close, fast=None, slow=None, signal=None, scalar=None, offset=None, **kw
     if close is None: return
 
     # Calculate Result
-    smi = tsi(close, fast=fast, slow=slow, scalar=scalar)
-    signalma = ema(smi, signal)
+    tsi_df = tsi(close, fast=fast, slow=slow, signal=signal, scalar=scalar)
+    smi = tsi_df.iloc[:, 0]
+    signalma = tsi_df.iloc[:, 1]
     osc = smi - signalma
 
     # Offset

--- a/tests/test_indicator_momentum.py
+++ b/tests/test_indicator_momentum.py
@@ -453,8 +453,8 @@ class TestMomentum(TestCase):
 
     def test_tsi(self):
         result = pandas_ta.tsi(self.close)
-        self.assertIsInstance(result, Series)
-        self.assertEqual(result.name, "TSI_13_25")
+        self.assertIsInstance(result, DataFrame)
+        self.assertEqual(result.name, "TSI_13_25_13")
 
     def test_uo(self):
         result = pandas_ta.uo(self.high, self.low, self.close)


### PR DESCRIPTION
Hi KJ,

Thanks for allowing me to contribute to this awesome project! This PR adds the signal line to the TSI as discussed in issue #351.

I have also adjusted the SMI slightly to account for the change.

I have tested and verified the changes manually as well as via your momentum testing script:
![Screenshot from 2021-07-25 18-23-00](https://user-images.githubusercontent.com/52344837/126896332-da8ce25f-ffab-4744-92f4-a73d2c233657.png)
![Screenshot from 2021-07-25 18-07-47](https://user-images.githubusercontent.com/52344837/126896330-cb269ae5-a914-49eb-ba56-46fe3e43ab82.png)

I used a default signal value of `13` which is in line with that of TradingView.

Regards,
Daniel