### PR TITLE
Fix 'verbose' option in multiprocessing mode

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -743,12 +743,12 @@ class AnalysisIndicators(BasePandasObject):
                     default_ta = [(ind, tuple(), kwargs) for ind in ta]
                     # All and Categorical multiprocessing pool.
                     if all_ordered:
-                        if Imports["tqdm"]:
+                        if Imports["tqdm"] and verbose:
                             results = tqdm(pool.imap(self._mp_worker, default_ta, _chunksize)) # Order over Speed
                         else:
                             results = pool.imap(self._mp_worker, default_ta, _chunksize) # Order over Speed
                     else:
-                        if Imports["tqdm"]:
+                        if Imports["tqdm"] and verbose:
                             results = tqdm(pool.imap_unordered(self._mp_worker, default_ta, _chunksize)) # Speed over Order
                         else:
                             results = pool.imap_unordered(self._mp_worker, default_ta, _chunksize) # Speed over Order


### PR DESCRIPTION
The verbose option does not take effect multiprocessing mode. See L746 and L751 in core.py.
The "without multiprocessing" part deals with this option correctly (L772 and L782).

This may not be an issue when use in jupyter notebook, but it's a bit annoying when running in terminal, especially within for loop.