### PR TITLE
Fix required length for MACD

### DIFF
--- a/pandas_ta/momentum/macd.py
+++ b/pandas_ta/momentum/macd.py
@@ -13,7 +13,7 @@ def macd(close, fast=None, slow=None, signal=None, talib=None, offset=None, **kw
     signal = int(signal) if signal and signal > 0 else 9
     if slow < fast:
         fast, slow = slow, fast
-    close = verify_series(close, max(fast, slow, signal))
+    close = verify_series(close, slow + signal)
     offset = get_offset(offset)
     mode_tal = bool(talib) if isinstance(talib, bool) else True
 


### PR DESCRIPTION
Current minimum length of `max(fast, slow, signal)` for MACD is incorrect and should instead be `slow + signal` because the signal is calculated based on the result of `fast ema - slow ema`. Also, since there is already a comparison between slow and fast that ensures that slow is longer, there is no need for `max(fast, slow)`.