### PR TITLE
Fix required length for stoch and stochrsi

### DIFF
--- a/pandas_ta/momentum/stoch.py
+++ b/pandas_ta/momentum/stoch.py
@@ -10,7 +10,7 @@ def stoch(high, low, close, k=None, d=None, smooth_k=None, mamode=None, offset=N
     k = k if k and k > 0 else 14
     d = d if d and d > 0 else 3
     smooth_k = smooth_k if smooth_k and smooth_k > 0 else 3
-    _length = max(k, d, smooth_k)
+    _length = k + d + smooth_k
     high = verify_series(high, _length)
     low = verify_series(low, _length)
     close = verify_series(close, _length)

--- a/pandas_ta/momentum/stochrsi.py
+++ b/pandas_ta/momentum/stochrsi.py
@@ -12,7 +12,7 @@ def stochrsi(close, length=None, rsi_length=None, k=None, d=None, mamode=None, o
     rsi_length = rsi_length if rsi_length and rsi_length > 0 else 14
     k = k if k and k > 0 else 3
     d = d if d and d > 0 else 3
-    close = verify_series(close, max(length, rsi_length, k, d))
+    close = verify_series(close, length + rsi_length + k + d)
     offset = get_offset(offset)
     mamode = mamode if isinstance(mamode, str) else "sma"
 


### PR DESCRIPTION
Similar to #397, minimum lengths for stoch and stochrsi are additive. There are probably other similar cases, but I don't have the time to go through a full audit. I'm just fixing ones I happen to come across.