### PR TITLE
Fix cross utility edge case

### DIFF
--- a/pandas_ta/utils/_signals.py
+++ b/pandas_ta/utils/_signals.py
@@ -77,6 +77,8 @@ def cross(series_a: Series, series_b: Series, above: bool = True, asint: bool = 
     previous = series_a.shift(1) < series_b.shift(1)  # previous is below
     # above if both are true, below if both are false
     cross = current & previous if above else ~current & ~previous
+    # ensure there is no cross on the first entry
+    cross[0] = False
 
     if asint:
         cross = cross.astype(int)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ from .config import sample_data
 from .context import pandas_ta
 
 from unittest import skip, TestCase
-from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -139,6 +138,9 @@ class TestUtilities(TestCase):
         self.assertIsInstance(result, Series)
         npt.assert_array_equal(result, self.crosseddf["crossed"])
 
+        result = self.utils.cross(self.crosseddf["a"], self.crosseddf["b"], above=False)
+        self.assertFalse(result[0])
+
     def test_df_dates(self):
         result = self.utils.df_dates(self.data)
         self.assertEqual(None, result)
@@ -180,7 +182,6 @@ class TestUtilities(TestCase):
 
         npt.assert_allclose(self.utils.fibonacci(n=5, zero=True, weighted=True), np.array([0, 1 / 12, 1 / 12, 1 / 6, 1 / 4, 5 / 12]))
         npt.assert_allclose(self.utils.fibonacci(n=5, zero=False, weighted=True), np.array([1 / 12, 1 / 12, 1 / 6, 1 / 4, 5 / 12]))
-
 
     def test_geometric_mean(self):
         returns = pandas_ta.percent_return(self.data.close)


### PR DESCRIPTION
This is the most explicit implementation, which allows this edge case to be addressed directly. In this way, other developers should be able to understand the purpose for this specific detail. There may be a fancier way of handling this, but it would likely obscure the logic, so I have not pursed it.

I have also added on to the test case to ensure that first entry is always `False`. Even if another implementation is chosen, this should be specifically checked to ensure that a false signal is not generated. I have used the existing fixture by swapping the order of the series in the `cross()` invocation. This ensure that `series_a[0] <= series_b[0]` to address the edge case identified. If this condition seems out of place, it may warrant a comment, which I will add if desired.

Closes #426 