### PR TITLE
talib kwarg propagation

### DIFF
--- a/pandas_ta/momentum/apo.py
+++ b/pandas_ta/momentum/apo.py
@@ -53,8 +53,8 @@ def apo(close, fast=None, slow=None, mamode=None, talib=None, offset=None, **kwa
         from talib import APO
         apo = APO(close, fast, slow, tal_ma(mamode))
     else:
-        fastma = ma(mamode, close, length=fast)
-        slowma = ma(mamode, close, length=slow)
+        fastma = ma(mamode, close, length=fast, talib=mode_tal)
+        slowma = ma(mamode, close, length=slow, talib=mode_tal)
         apo = fastma - slowma
 
     # Offset

--- a/pandas_ta/momentum/cci.py
+++ b/pandas_ta/momentum/cci.py
@@ -57,8 +57,8 @@ def cci(high, low, close, length=None, c=None, talib=None, offset=None, **kwargs
         from talib import CCI
         cci = CCI(high, low, close, length)
     else:
-        typical_price = hlc3(high=high, low=low, close=close)
-        mean_typical_price = sma(typical_price, length=length)
+        typical_price = hlc3(high=high, low=low, close=close, talib=mode_tal)
+        mean_typical_price = sma(typical_price, length=length, talib=mode_tal)
         mad_typical_price = mad(typical_price, length=length)
 
         cci = typical_price - mean_typical_price

--- a/pandas_ta/momentum/dm.py
+++ b/pandas_ta/momentum/dm.py
@@ -71,8 +71,8 @@ def dm(high, low, length=None, mamode=None, talib=None, drift=None, offset=None,
         neg_ = neg_.apply(zero)
 
         # Not the same values as TA Lib's -+DM (Good First Issue)
-        pos = ma(mamode, pos_, length=length)
-        neg = ma(mamode, neg_, length=length)
+        pos = ma(mamode, pos_, length=length, talib=mode_tal)
+        neg = ma(mamode, neg_, length=length, talib=mode_tal)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/momentum/macd.py
+++ b/pandas_ta/momentum/macd.py
@@ -67,16 +67,16 @@ def macd(close, fast=None, slow=None, signal=None, talib=None, offset=None, **kw
         from talib import MACD
         macd, signalma, histogram = MACD(close, fast, slow, signal)
     else:
-        fastma = ema(close, length=fast)
-        slowma = ema(close, length=slow)
+        fastma = ema(close, length=fast, talib=mode_tal)
+        slowma = ema(close, length=slow, talib=mode_tal)
 
         macd = fastma - slowma
-        signalma = ema(close=macd.loc[macd.first_valid_index():,], length=signal)
+        signalma = ema(close=macd.loc[macd.first_valid_index():,], length=signal, talib=mode_tal)
         histogram = macd - signalma
 
     if as_mode:
         macd = macd - signalma
-        signalma = ema(close=macd.loc[macd.first_valid_index():,], length=signal)
+        signalma = ema(close=macd.loc[macd.first_valid_index():,], length=signal, talib=mode_tal)
         histogram = macd - signalma
 
     # Offset

--- a/pandas_ta/momentum/ppo.py
+++ b/pandas_ta/momentum/ppo.py
@@ -62,12 +62,12 @@ def ppo(close, fast=None, slow=None, signal=None, scalar=None, mamode=None, tali
         from talib import PPO
         ppo = PPO(close, fast, slow, tal_ma(mamode))
     else:
-        fastma = ma(mamode, close, length=fast)
-        slowma = ma(mamode, close, length=slow)
+        fastma = ma(mamode, close, length=fast, talib=mode_tal)
+        slowma = ma(mamode, close, length=slow, talib=mode_tal)
         ppo = scalar * (fastma - slowma)
         ppo /= slowma
 
-    signalma = ma("ema", ppo, length=signal)
+    signalma = ma("ema", ppo, length=signal, talib=mode_tal)
     histogram = ppo - signalma
 
     # Offset

--- a/pandas_ta/momentum/roc.py
+++ b/pandas_ta/momentum/roc.py
@@ -49,7 +49,7 @@ def roc(close, length=None, scalar=None, talib=None, offset=None, **kwargs):
         from talib import ROC
         roc = ROC(close, length)
     else:
-        roc = scalar * mom(close=close, length=length) / close.shift(length)
+        roc = scalar * mom(close=close, length=length, talib=mode_tal) / close.shift(length)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/momentum/stochf.py
+++ b/pandas_ta/momentum/stochf.py
@@ -68,7 +68,7 @@ def stochf(high, low, close, k=None, d=None, mamode=None, talib=None, offset=Non
 
         stochf_k = 100 * (close - lowest_low)
         stochf_k /= non_zero_range(highest_high, lowest_low)
-        stochf_d = ma(mamode, stochf_k.loc[stochf_k.first_valid_index():,], length=d)
+        stochf_d = ma(mamode, stochf_k.loc[stochf_k.first_valid_index():,], length=d, talib=mode_tal)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/overlap/dema.py
+++ b/pandas_ta/overlap/dema.py
@@ -49,8 +49,8 @@ def dema(close, length=None, talib=None, offset=None, **kwargs):
         from talib import DEMA
         dema = DEMA(close, length)
     else:
-        ema1 = ema(close=close, length=length)
-        ema2 = ema(close=ema1, length=length)
+        ema1 = ema(close=close, length=length, talib=mode_tal)
+        ema2 = ema(close=ema1, length=length, talib=mode_tal)
         dema = 2 * ema1 - ema2
 
     # Offset

--- a/pandas_ta/overlap/t3.py
+++ b/pandas_ta/overlap/t3.py
@@ -65,12 +65,12 @@ def t3(close, length=None, a=None, talib=None, offset=None, **kwargs):
         c3 = -6 * a**2 - 3 * a - 3 * a**3
         c4 = a**3 + 3 * a**2 + 3 * a + 1
 
-        e1 = ema(close=close, length=length, **kwargs)
-        e2 = ema(close=e1, length=length, **kwargs)
-        e3 = ema(close=e2, length=length, **kwargs)
-        e4 = ema(close=e3, length=length, **kwargs)
-        e5 = ema(close=e4, length=length, **kwargs)
-        e6 = ema(close=e5, length=length, **kwargs)
+        e1 = ema(close=close, length=length, talib=mode_tal, **kwargs)
+        e2 = ema(close=e1, length=length, talib=mode_tal, **kwargs)
+        e3 = ema(close=e2, length=length, talib=mode_tal, **kwargs)
+        e4 = ema(close=e3, length=length, talib=mode_tal, **kwargs)
+        e5 = ema(close=e4, length=length, talib=mode_tal, **kwargs)
+        e6 = ema(close=e5, length=length, talib=mode_tal, **kwargs)
         t3 = c1 * e6 + c2 * e5 + c3 * e4 + c4 * e3
 
     # Offset

--- a/pandas_ta/overlap/tema.py
+++ b/pandas_ta/overlap/tema.py
@@ -50,9 +50,9 @@ def tema(close, length=None, talib=None, offset=None, **kwargs):
         from talib import TEMA
         tema = TEMA(close, length)
     else:
-        ema1 = ema(close=close, length=length, **kwargs)
-        ema2 = ema(close=ema1, length=length, **kwargs)
-        ema3 = ema(close=ema2, length=length, **kwargs)
+        ema1 = ema(close=close, length=length, talib=mode_tal, **kwargs)
+        ema2 = ema(close=ema1, length=length, talib=mode_tal, **kwargs)
+        ema3 = ema(close=ema2, length=length, talib=mode_tal, **kwargs)
         tema = 3 * (ema1 - ema2) + ema3
 
     # Offset

--- a/pandas_ta/overlap/trima.py
+++ b/pandas_ta/overlap/trima.py
@@ -52,8 +52,8 @@ def trima(close, length=None, talib=None, offset=None, **kwargs):
         trima = TRIMA(close, length)
     else:
         half_length = round(0.5 * (length + 1))
-        sma1 = sma(close, length=half_length)
-        trima = sma(sma1, length=half_length)
+        sma1 = sma(close, length=half_length, talib=mode_tal)
+        trima = sma(sma1, length=half_length, talib=mode_tal)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/statistics/stdev.py
+++ b/pandas_ta/statistics/stdev.py
@@ -48,7 +48,7 @@ def stdev(close, length=None, ddof=None, talib=None, offset=None, **kwargs):
         from talib import STDDEV
         stdev = STDDEV(close, length)
     else:
-        stdev = variance(close=close, length=length, ddof=ddof, talib=False).apply(npsqrt)
+        stdev = variance(close=close, length=length, ddof=ddof, talib=mode_tal).apply(npsqrt)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/volatility/atr.py
+++ b/pandas_ta/volatility/atr.py
@@ -72,8 +72,8 @@ def atr(high, low, close, length=None, mamode=None, talib=None, drift=None, offs
         from talib import ATR
         atr = ATR(high, low, close, length)
     else:
-        tr = true_range(high=high, low=low, close=close, drift=drift)
-        atr = ma(mamode, tr, length=length)
+        tr = true_range(high=high, low=low, close=close, drift=drift, talib=mode_tal)
+        atr = ma(mamode, tr, length=length, talib=mode_tal)
 
     percentage = kwargs.pop("percent", False)
     if percentage:

--- a/pandas_ta/volatility/bbands.py
+++ b/pandas_ta/volatility/bbands.py
@@ -69,7 +69,7 @@ def bbands(close, length=None, std=None, ddof=0, mamode=None, talib=None, offset
         from talib import BBANDS
         upper, mid, lower = BBANDS(close, length, std, std, tal_ma(mamode))
     else:
-        standard_deviation = stdev(close=close, length=length, ddof=ddof)
+        standard_deviation = stdev(close=close, length=length, ddof=ddof, talib=False)
         deviations = std * standard_deviation
         # deviations = std * standard_deviation.loc[standard_deviation.first_valid_index():,]
 

--- a/pandas_ta/volatility/bbands.py
+++ b/pandas_ta/volatility/bbands.py
@@ -69,11 +69,11 @@ def bbands(close, length=None, std=None, ddof=0, mamode=None, talib=None, offset
         from talib import BBANDS
         upper, mid, lower = BBANDS(close, length, std, std, tal_ma(mamode))
     else:
-        standard_deviation = stdev(close=close, length=length, ddof=ddof, talib=False)
+        standard_deviation = stdev(close=close, length=length, ddof=ddof, talib=mode_tal)
         deviations = std * standard_deviation
         # deviations = std * standard_deviation.loc[standard_deviation.first_valid_index():,]
 
-        mid = ma(mamode, close, length=length, **kwargs)
+        mid = ma(mamode, close, length=length, talib=mode_tal, **kwargs)
         lower = mid - deviations
         upper = mid + deviations
 

--- a/pandas_ta/volatility/natr.py
+++ b/pandas_ta/volatility/natr.py
@@ -55,7 +55,7 @@ def natr(high, low, close, length=None, scalar=None, mamode=None, talib=None, dr
         natr = NATR(high, low, close, length)
     else:
         natr = scalar / close
-        natr *= atr(high=high, low=low, close=close, length=length, mamode=mamode, drift=drift, offset=offset, **kwargs)
+        natr *= atr(high=high, low=low, close=close, length=length, mamode=mamode, drift=drift, offset=offset, talib=mode_tal, **kwargs)
 
     # Offset
     if offset != 0:

--- a/pandas_ta/volume/adosc.py
+++ b/pandas_ta/volume/adosc.py
@@ -62,9 +62,9 @@ def adosc(high, low, close, volume, open_=None, fast=None, slow=None, talib=None
         from talib import ADOSC
         adosc = ADOSC(high, low, close, volume, fast, slow)
     else:
-        ad_ = ad(high=high, low=low, close=close, volume=volume, open_=open_)
-        fast_ad = ema(close=ad_, length=fast, **kwargs)
-        slow_ad = ema(close=ad_, length=slow, **kwargs)
+        ad_ = ad(high=high, low=low, close=close, volume=volume, open_=open_, talib=mode_tal)
+        fast_ad = ema(close=ad_, length=fast, **kwargs, talib=mode_tal)
+        slow_ad = ema(close=ad_, length=slow, **kwargs, talib=mode_tal)
         adosc = fast_ad - slow_ad
 
     # Offset

--- a/pandas_ta/volume/mfi.py
+++ b/pandas_ta/volume/mfi.py
@@ -61,7 +61,7 @@ def mfi(high, low, close, volume, length=None, talib=None, drift=None, offset=No
         from talib import MFI
         mfi = MFI(high, low, close, volume, length)
     else:
-        typical_price = hlc3(high=high, low=low, close=close)
+        typical_price = hlc3(high=high, low=low, close=close, talib=mode_tal)
         raw_money_flow = typical_price * volume
 
         tdf = DataFrame({"diff": 0, "rmf": raw_money_flow, "+mf": 0, "-mf": 0})


### PR DESCRIPTION
Hello Kevin,

I've noticed that the _talib_ kwarg is not propagated to inner function calls in some places. For example calling `bbands(.., talib=False)` has no effect on internal call to `stdev()` - which still uses Ta-Lib implementation of stdev.

Thanks,
Olaf