### PR TITLE
using same parameters across nested function of stoch

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -1100,11 +1100,11 @@ class AnalysisIndicators(BasePandasObject):
         result = stc(close=close, ma1=ma1, ma2=ma2, osc=osc, tclength=tclength, fast=fast, slow=slow, factor=factor, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
-    def stoch(self, fast_k=None, slow_k=None, slow_d=None, mamode=None, offset=None, **kwargs):
+    def stoch(self, k=None, d=None, smooth_k=None, mamode=None, offset=None, **kwargs):
         high = self._get_column(kwargs.pop("high", "high"))
         low = self._get_column(kwargs.pop("low", "low"))
         close = self._get_column(kwargs.pop("close", "close"))
-        result = stoch(high=high, low=low, close=close, fast_k=fast_k, slow_k=slow_k, slow_d=slow_d, mamode=mamode, offset=offset, **kwargs)
+        result = stoch(high=high, low=low, close=close,  k=k, d=d, smooth_k=smooth_k, mamode=mamode, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
     def stochrsi(self, length=None, rsi_length=None, k=None, d=None, mamode=None, offset=None, **kwargs):


### PR DESCRIPTION
different signature across nested functions, so user argument never passed 
stoch function signature as followed
```
stoch(high, low, close, k=None, d=None, smooth_k=None, mamode=None, offset=None, **kwargs)
```
where the core module has the following signature. 
```
stoch(self, fast_k=None, slow_k=None, slow_d=None, mamode=None, offset=None, **kwargs)
```

So make a consistent signature across multiple functions.