### PR TITLE
FutreWarning during execution of macd function

### DIFF
--- a/pandas_ta/overlap/ema.py
+++ b/pandas_ta/overlap/ema.py
@@ -83,8 +83,8 @@ def ema(
     else:
         if presma:  # TA Lib implementation
             close = close.copy()
-            sma_nth = close[0:length].mean()
-            close[:length - 1] = nan
+            sma_nth = close.iloc[0:length].mean()
+            close.iloc[:length - 1] = nan
             close.iloc[length - 1] = sma_nth
         ema = close.ewm(span=length, adjust=adjust).mean()
 


### PR DESCRIPTION
During executing macd function there is  FutreWarning:
FutureWarning: The behavior of series[i:j]with an integer-dtype index is deprecated. In a future version, this will be treated as *label-based* indexing, consistent with e.g.series[i]lookups. To retain the old behavior, useseries.iloc[i:j]. To get the future behavior, use series.loc[i:j].
 
This was described in #610 .