### PR TITLE
Fix tclength parameter name in STC doc

### DIFF
--- a/pandas_ta/momentum/stc.py
+++ b/pandas_ta/momentum/stc.py
@@ -106,11 +106,11 @@ Schaff Trend Cycle should be calculated.
 
 Feed external moving averages:
 Internally calculation..
-    stc = ta.stc(close=df["close"], tclen=stc_tclen, fast=ma1_interval, slow=ma2_interval, factor=stc_factor)
+    stc = ta.stc(close=df["close"], tclength=stc_tclen, fast=ma1_interval, slow=ma2_interval, factor=stc_factor)
 becomes..
     extMa1 = df.ta.zlma(close=df["close"], length=ma1_interval, append=True)
     extMa2 = df.ta.ema(close=df["close"], length=ma2_interval, append=True)
-    stc = ta.stc(close=df["close"], tclen=stc_tclen, ma1=extMa1, ma2=extMa2, factor=stc_factor)
+    stc = ta.stc(close=df["close"], tclength=stc_tclen, ma1=extMa1, ma2=extMa2, factor=stc_factor)
 
 The same goes for osc=, which allows the input of an externally calculated oscillator, overriding ma1 & ma2.
 
@@ -127,7 +127,7 @@ Calculation:
 
 Args:
     close (pd.Series): Series of 'close's, used for indexing Series, mandatory
-    tclen (int): SchaffTC Signal-Line length.  Default: 10 (adjust to the half of cycle)
+    tclength (int): SchaffTC Signal-Line length.  Default: 10 (adjust to the half of cycle)
     fast (int): The short period.   Default: 12
     slow (int): The long period.   Default: 26
     factor (float): smoothing factor for last stoch. calculation.   Default: 0.5


### PR DESCRIPTION
This update docs to match the correct parameter name for "tclength" on STC.
Fixes #634