### PR TITLE
get_offset: more robust casting to int

### DIFF
--- a/pandas_ta/utils/_core.py
+++ b/pandas_ta/utils/_core.py
@@ -31,7 +31,10 @@ def get_drift(x: int) -> int:
 
 def get_offset(x: int) -> int:
     """Returns an int, otherwise defaults to zero."""
-    return int(x) if isinstance(x, int) else 0
+    try:
+        return int(x)
+    except ValueError:
+        return 0
 
 
 def is_datetime_ordered(df: DataFrame or Series) -> bool:


### PR DESCRIPTION
Expands the validation of integers to include (for instance) numpy.int64.  Raises a ValueError if the type cannot be cast