### PR TITLE
Add warning docstring about data leakage on ML

### DIFF
--- a/pandas_ta/overlap/ichimoku.py
+++ b/pandas_ta/overlap/ichimoku.py
@@ -15,6 +15,10 @@ def ichimoku(
 
     Developed Pre WWII as a forecasting model for financial markets.
 
+    WARNING: This function may leak future data when used for machine learning
+        if include_chikou=True (default). Set lookahead=False to avoid data leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/60#.
+
     Sources:
         https://www.tradingtechnologies.com/help/x-study/technical-indicator-definitions/ichimoku-ich/
 
@@ -32,6 +36,7 @@ def ichimoku(
     Kwargs:
         fillna (value, optional): pd.DataFrame.fillna(value)
         fill_method (value, optional): Type of fill method
+        lookahead (value, optional): Set False to prevent data leakage by excluding the Chikou Span column from the output.
 
     Returns:
         pd.DataFrame: Two DataFrames.

--- a/pandas_ta/overlap/ssf.py
+++ b/pandas_ta/overlap/ssf.py
@@ -60,6 +60,10 @@ def ssf(
     For Everget's calculation on TradingView, set arguments:
         pi = np.pi, sqrt2 = np.sqrt(2)
 
+    WARNING: This function may leak future data when used for machine learning.
+        Setting lookahead=False does not currently prevent leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/667.
+
     Sources:
         http://traders.com/documentation/feedbk_docs/2014/01/traderstips.html
         https://www.tradingview.com/script/VdJy0yBJ-Ehlers-Super-Smoother-Filter/

--- a/pandas_ta/statistics/kurtosis.py
+++ b/pandas_ta/statistics/kurtosis.py
@@ -12,6 +12,10 @@ def kurtosis(
 
     Calculates the Kurtosis over a rolling period.
 
+    WARNING: This function may leak future data when used for machine learning.
+        Setting lookahead=False does not currently prevent leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/667.
+
     Args:
         close (pd.Series): Series of 'close's
         length (int): It's period. Default: 30

--- a/pandas_ta/statistics/skew.py
+++ b/pandas_ta/statistics/skew.py
@@ -12,6 +12,10 @@ def skew(
 
     Calculates the Skew over a rolling period.
 
+    WARNING: This function may leak future data when used for machine learning.
+        Setting lookahead=False does not currently prevent leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/667.
+
     Args:
         close (pd.Series): Series of 'close's
         length (int): It's period. Default: 30

--- a/pandas_ta/statistics/tos_stdevall.py
+++ b/pandas_ta/statistics/tos_stdevall.py
@@ -16,6 +16,10 @@ def tos_stdevall(
     which returns the standard deviation of data for the entire plot or for
     the interval of the last bars defined by the length parameter.
 
+    WARNING: This function may leak future data when used for machine learning.
+        Setting lookahead=False does not currently prevent leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/667.
+
     Sources:
         https://tlc.thinkorswim.com/center/reference/thinkScript/Functions/Statistical/StDevAll
 

--- a/pandas_ta/trend/dpo.py
+++ b/pandas_ta/trend/dpo.py
@@ -14,6 +14,10 @@ def dpo(
     Is an indicator designed to remove trend from price and make it easier to
     identify cycles.
 
+    WARNING: This function may leak future data when used for machine learning
+        if centered=True (default). Set lookahead=False to avoid data leakage.
+        See https://github.com/twopirllc/pandas-ta/issues/60#.
+
     Sources:
         https://www.tradingview.com/scripts/detrendedpriceoscillator/
         https://www.fidelity.com/learning-center/trading-investing/technical-analysis/technical-indicator-guide/dpo
@@ -29,6 +33,7 @@ def dpo(
     Kwargs:
         fillna (value, optional): pd.DataFrame.fillna(value)
         fill_method (value, optional): Type of fill method
+        lookahead (value, optional): Set False to prevent centering and avoid potential data leakage.
 
     Returns:
         pd.Series: New feature generated.


### PR DESCRIPTION
I added some warnings on dpo and ichimoku so that people can find their potential data leakage more easily.
Also `lookahead` arg was not mentioned, so I added it as well.

Discussion here: https://github.com/twopirllc/pandas-ta/issues/60#