### PR TITLE
Modified vp.py to consider volume when open == close

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,9 +18,9 @@ print(ta.version)
 $ pip list
 ```
 
-**Did you upgrade? Did the upgrade resolve the issue?**
+**Have you tried the _development_ version? Did it resolve the issue?**
 ```sh
-$ pip install -U git+https://github.com/twopirllc/pandas-ta
+$ pip install -U git+https://github.com/twopirllc/pandas-ta.git@development
 ```
 
 **Describe the bug**


### PR DESCRIPTION
This PR is the result from #615 where further explanation of the issue itself is detailed.

**tldr;** When `open == close`  `vp.py` does not know if volume should be positive or negative, so it is ignored.

Modified `vp.py` to consider cases where `open == close` where volume is considered "neutral" so it is not ignored / lost.