### PR TITLE
fix the cross func when values are nan

### DIFF
--- a/pandas_ta/utils/_signals.py
+++ b/pandas_ta/utils/_signals.py
@@ -73,10 +73,14 @@ def cross(series_a: Series, series_b: Series, above: bool = True, asint: bool = 
     series_b.apply(zero)
 
     # Calculate Result
-    current = series_a > series_b  # current is above
-    previous = series_a.shift(1) < series_b.shift(1)  # previous is below
-    # above if both are true, below if both are false
-    cross = current & previous if above else ~current & ~previous
+    if above:
+        current = series_a > series_b  # current is above
+        previous = series_a.shift(1) < series_b.shift(1)  # previous is below
+    else:
+        current = series_a < series_b # current is below
+        previous = series_a.shift(1) > series_b.shift(1) # previous is above  
+        
+    cross = current & previous 
 
     if asint:
         cross = cross.astype(int)


### PR DESCRIPTION
when one series has np.nan, and cross below (above = False) is used, current logic will treat those np.nan value comparison false, hence ~false as true. 

modified the logic a bit now it deals with np.nan correctly, as well as the edge case when two numbers are equal. 