### PR TITLE
Implement Connors RSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ Back to [Contents](#contents)
 * _Center of Gravity_: **cg**
 * _Chande Momentum Oscillator_: **cmo**
 * _Coppock Curve_: **coppock**
+* _Connors Relative Strenght Index_: **crsi**
 * _Correlation Trend Indicator_: **cti**
     * A wrapper for ```ta.linreg(series, r=True)```
 * _Directional Movement_: **dm**

--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -941,6 +941,12 @@ class AnalysisIndicators(object):
         result = coppock(close=close, length=length, fast=fast, slow=slow, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
+    def crsi(self, length_rsi=None, length_streak=None, length_rank=None,
+    drift=None, offset=None, **kwargs: DictLike):
+        close = self._get_column(kwargs.pop("close", "close"))
+        result = crsi(close=close, length_rsi=length_rsi, length_streak=length_streak, length_rank=length_rank, drift=drift, offset=offset, **kwargs)
+        return self._post_process(result, **kwargs)
+
     def cti(self, length=None, offset=None, **kwargs: DictLike):
         close = self._get_column(kwargs.pop("close", "close"))
         result = cti(close=close, length=length, offset=offset, **kwargs)

--- a/pandas_ta/maps.py
+++ b/pandas_ta/maps.py
@@ -49,7 +49,7 @@ Category: Dict[str, ListStr] = {
     # Momentum
     "momentum": [
         "ao", "apo", "bias", "bop", "brar", "cci", "cfo", "cg", "cmo",
-        "coppock", "cti", "er", "eri", "fisher", "inertia", "kdj", "kst",
+        "coppock", "crsi", "cti", "er", "eri", "fisher", "inertia", "kdj", "kst",
         "macd", "mom", "pgo", "ppo", "psl", "qqe", "roc", "rsi", "rsx",
         "rvgi", "slope", "smi", "squeeze", "squeeze_pro", "stc", "stoch",
         "stochf", "stochrsi", "td_seq", "tmo", "trix", "tsi", "uo", "willr"

--- a/pandas_ta/momentum/__init__.py
+++ b/pandas_ta/momentum/__init__.py
@@ -9,6 +9,7 @@ from .cfo import cfo
 from .cg import cg
 from .cmo import cmo
 from .coppock import coppock
+from .crsi import crsi
 from .cti import cti
 from .dm import dm
 from .er import er
@@ -53,6 +54,7 @@ __all__ = [
     "cg",
     "cmo",
     "coppock",
+    "crsi",
     "cti",
     "dm",
     "er",

--- a/pandas_ta/momentum/crsi.py
+++ b/pandas_ta/momentum/crsi.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from pandas import Series
+
+from pandas_ta._typing import Array1d, DictLike, Int, IntFloat
+from pandas_ta.maps import Imports
+from pandas_ta.momentum.rsi import rsi
+from pandas_ta.utils import (
+    v_drift,
+    v_offset,
+    v_pos_default,
+    v_scalar,
+    v_series,
+    v_talib,
+)
+
+
+def calculate_streak_conv(prices: Array1d) -> Array1d:
+    """Calculate the streak of consecutive price increases or decreases.
+
+    This function computes the streak of consecutive daily price increases
+    or decreases. A positive streak indicates consecutive days of price
+    increases, while a negative streak indicates consecutive days of price
+    decreases. The streak is reset to zero when the direction of the price
+    change reverses.
+
+    Parameters:
+        prices (Array1d): An array of prices.
+
+    Returns:
+        Array1d: An array representing the streak of price changes.
+
+    The function first calculates the difference between consecutive prices.
+    It then assigns a +1 for each positive change, -1 for each negative change,
+    and 0 for no change. The result is an array where each element represents
+    the streak value for that day.
+
+    Example:
+    >>> prices = np.array([100, 101, 102, 100, 100, 101, 102, 103])
+    >>> result = calculate_streak_conv(prices)
+    >>> expected_result = np.array([0, 1, 1, -1, 0, 1, 1, 1])
+    >>> np.array_equal(result, expected_result)
+    True
+
+    """
+    diff = np.diff(prices)
+    streaks = np.sign(diff)
+    return np.concatenate(([0], streaks))
+
+
+def calculate_percent_rank(close: Series, lookback: Int) -> Series:
+    """Calculate the Percent Rank of daily returns over given period.
+
+    The Percent Rank compares today's return with the one-day returns from each
+    of the previous days within the lookback period. It measures the percentage
+    of these past returns that are less than the current day's return.
+
+    Args:
+        close (Series): Series of 'close' prices.
+        lookback (Int): The lookback period for calculating the Percent Rank.
+
+    Returns:
+        Series: A Pandas Series containing the Percent Rank values.
+
+    The function first calculates the daily percentage returns of the 'close'
+    prices.It then creates a rolling window of these returns and compares each
+    value in the window to the current value (the last value in each window).
+    The Percent Rank is calculated as the percentage of values in each window
+    that are less than the current value. The result is a Series where the
+    initial part (up to 'lookback - 1') is padded with NaNs, and the rest
+    contains the Percent Rank values.
+
+    Example:
+    >>> close = Series([100, 80, 75, 123, 140, 80, 70, 40, 100, 120])
+    >>> result = calculate_percent_rank(close, 3)
+    >>> expected_result = Series([np.nan, np.nan, np.nan, \
+        66.666667, 66.666667, 0.0, 33.333333, 0.0, 100.0, 66.666667])
+    >>> np.allclose(result, expected_result, rtol=1e-6, equal_nan=True)
+    True
+
+    """
+
+    daily_returns_np = close.pct_change().to_numpy()
+
+    rolling_windows = np.lib.stride_tricks.sliding_window_view(
+        daily_returns_np, window_shape=(lookback + 1,)
+    )
+    comparison_matrix = rolling_windows[:, :-1] < rolling_windows[:, -1, np.newaxis]
+
+    percent_ranks = np.nanmean(comparison_matrix, axis=1) * 100
+    padded_percent_ranks = np.full(len(close), np.nan)
+    padded_percent_ranks[lookback:] = percent_ranks
+
+    return Series(padded_percent_ranks, index=close.index)
+
+
+def crsi(
+    close: Series,
+    length_rsi: Int = None,
+    length_streak: Int = None,
+    length_rank: Int = None,
+    scalar: IntFloat = None,
+    talib: bool = None,
+    drift: Int = None,
+    offset: Int = None,
+    **kwargs: DictLike,
+) -> Series:
+    """Connors Relative Strength Index (RSI)
+
+    Connors RSI (CRSI) integrates Relative Strength Index (RSI), UpDown Length,
+    and Rate of Change (ROC) of RSI components to evaluate overbought and
+    oversold conditions in financial markets, providing insights into price
+    momentum and potential reversals.
+
+    Sources:
+        Connors, L., Alvarez, C., & Radtke, M. (2012). An Introduction to
+        ConnorsRSI. Connors Research Trading Strategy Series.
+        ISBN 978-0-9853072-9-5.
+        Retrieved from https://alvarezquanttrading.com/blog/connorsrsi-analysis/
+        https://www.tradingview.com/support/solutions/43000502017-connors-rsi-crsi/
+
+    Args:
+        close (pd.Series): Series of 'close's
+        length_rsi (int): It's period. Default: 3
+        length_streak (int): It's period. Default: 2
+        length_rank (int): It's period. Default: 100
+        scalar (float): How much to magnify. Default: 100
+        talib (bool): Use TAlib for RSI if available. Default: True
+        drift (int): The difference period. Default: 1
+        offset (int): How many periods to offset the result. Default: 0
+
+    Kwargs:
+        fillna (value, optional): pd.DataFrame.fillna(value)
+        fill_method (value, optional): Type of fill method
+
+    Returns:
+        pd.Series: New feature generated
+
+    """
+
+    # Validate
+    length_rsi = v_pos_default(length_rsi, 3)
+    length_streak = v_pos_default(length_streak, 2)
+    length_rank = v_pos_default(length_rank, 100)
+    _length = max(length_rsi, length_streak, length_rank)
+    close = v_series(close, _length)
+
+    if "length" in kwargs:
+        kwargs.pop("length")
+
+    if close is None:
+        return None
+
+    scalar = v_scalar(scalar, 100)
+    mode_tal = v_talib(talib)
+    drift = v_drift(drift)
+    offset = v_offset(offset)
+
+    # Initial streaks calculation
+    streak = Series(calculate_streak_conv(close.to_numpy()), index=close.index)
+
+    if Imports["talib"] and mode_tal:
+        from talib import RSI
+
+        close_rsi = RSI(close, length_rsi)
+        streak_rsi = RSI(streak, length_streak)
+
+    # Both TA-lib and Pandas-TA use the Wilder's RSI and its smoothing
+    # function.
+    else:
+        close_rsi = rsi(
+            close,
+            length=length_rsi,
+            scalar=scalar,
+            talib=talib,
+            drift=drift,
+            offset=offset,
+            **kwargs,
+        )
+
+        streak_rsi = rsi(
+            streak,
+            length=length_streak,
+            scalar=scalar,
+            talib=talib,
+            drift=drift,
+            offset=offset,
+            **kwargs,
+        )
+
+    # Percent rank and final arithmetic mean
+    percent_rank = calculate_percent_rank(close, length_rank)
+    crsi = (close_rsi + streak_rsi + percent_rank) / 3.0
+
+    # Offset
+    if offset != 0:
+        crsi = crsi.shift(offset)
+
+    # Fill
+    if "fillna" in kwargs:
+        crsi.fillna(kwargs["fillna"], inplace=True)
+    if "fill_method" in kwargs:
+        crsi.fillna(method=kwargs["fill_method"], inplace=True)
+
+    # Name and Category
+    crsi.name = f"CRSI_{length_rsi}_{length_streak}_{length_rank}"
+    crsi.category = "momentum"
+
+    return crsi

--- a/tests/test_indicator_momentum.py
+++ b/tests/test_indicator_momentum.py
@@ -136,6 +136,12 @@ def test_cti(df):
     assert result.name == "CTI_12"
 
 
+def test_crsi(df):
+    result = ta.crsi(df.close)
+    assert isinstance(result, Series)
+    assert result.name == "CRSI_3_2_100"
+
+
 def test_er(df):
     result = ta.er(df.close)
     assert isinstance(result, Series)
@@ -637,9 +643,19 @@ def test_ext_coppock(df):
     assert df.columns[-1] == "COPC_11_14_10"
 
 
+def test_ext_crsi(df):
+    df.ta.crsi(append=True)
+    assert df.columns[-1] == "CRSI_3_2_100"
+
+
 def test_ext_cti(df):
     df.ta.cti(append=True)
     assert df.columns[-1] == "CTI_12"
+
+
+def test_ext_crsi(df):
+    df.ta.crsi(append=True)
+    assert df.columns[-1] == "CRSI_3_2_100"
 
 
 def test_ext_er(df):

--- a/tests/test_studies.py
+++ b/tests/test_studies.py
@@ -9,7 +9,7 @@ categories = DataFrame().ta.categories() + \
 [pytest.param(ta.CommonStudy, id="common"), pytest.param(ta.AllStudy, id="all")]
 
 # +/- when adding/removing indicators
-ALL_COLUMNS = 321
+ALL_COLUMNS = 322
 
 
 def test_all_study_props(all_study):
@@ -31,7 +31,7 @@ def test_common_study_props(common_study):
 
 
 @pytest.mark.parametrize("category,columns", [
-    ("candles", 70), ("cycles", 2), ("momentum", 77), ("overlap", 56),
+    ("candles", 70), ("cycles", 2), ("momentum", 78), ("overlap", 56),
     ("performance", 2), ("statistics", 16), ("transform", 5), ("trend", 29),
     ("volatility", 36), ("volume", 28),
     pytest.param(ta.AllStudy, ALL_COLUMNS, id=f"all-{ALL_COLUMNS}"),
@@ -89,7 +89,7 @@ def test_study_custom_e(df, custom_study_e, talib):
 
 @pytest.mark.parametrize("talib", [False, True])
 def test_study_all_multirun(df, all_study, talib):
-    all_columns = 608  # +/- when adding/removing indicators
+    all_columns = 609  # +/- when adding/removing indicators
     initial_columns = df.shape[1]
     df.ta.study(all_study, length=10, cores=0, talib=talib)
     df.ta.study(all_study, length=50, cores=0, talib=talib)


### PR DESCRIPTION
Implement the Connors RSI using the Wilder's RSI indicator, as discussed in #349 .
This implementation is using Pandas-TA built-in (W)RSI for the closing price and streak RSI, and using NumPy for the streaks computation and percent rank computation.
It was tested with OHLCVA timeseries with 1 million entries, and *timeit* shows that for the native RSI without TA-lib we have
```
Total execution time for crsi: 4.437666 seconds
Average execution time for crsi: 0.221883 seconds
```
while with TA-lib we have:
```
Total execution time for crsi: 3.447122 seconds
Average execution time for crsi: 0.172356 seconds
```
for an average of 20 runs.
The screenshot below shows only 251 trading days of OHLCVA data of a security, and the lookback period is 100 (the defaults are 2/3/100 for this indicator)

![crsi](https://github.com/twopirllc/pandas-ta/assets/387352/84ed6a78-922b-4ae7-9a68-9138ca69a0b7)

@twopirllc for convenience both the calculations to calculate the streak and the percent rank are in their own functions with docstrings and doctests. I don't know if you prefer to remove the doctests or leave them since you have your own unit tests. The sources as discussed in #349 are *An Introduction to ConnorsRSI*, by Connors, L., Alvarez, C., Radtke, M. (2012), ISBN: 978-0-9853072-9-5, and i confirmed with the original author about the RSI used. It was Wilder's RSI from *New Concepts in Technical Trading Systems*, , ISBN 0-89459-027-8.
Do note that the lookback period for the percent rank is 100 periods, so if a series starts at $t=0$ then we would only get the first $\text{CRSI}$ value at $t=100$.

The previous notebook for the [TMO indicator ](https://github.com/twopirllc/pandas-ta/pull/729) wasn't added to the [development branch](https://github.com/twopirllc/pandas-ta/tree/development/examples), I don't know if by omission or intention, but if there's interest in the notebook, i can submit another PR with a notebook that fixes the dates in the [TMO notebook](https://github.com/twopirllc/pandas-ta/pull/729) given earlier and that also adds the CRSI example from the screenshot above. The idea was to continue using this notebook to add more indicator examples as they're implemented.