### PR TITLE
Fix ROC and percent_return default length documentation

### DIFF
--- a/pandas_ta/momentum/roc.py
+++ b/pandas_ta/momentum/roc.py
@@ -43,7 +43,7 @@ def roc(
 
     Args:
         close (pd.Series): Series of 'close's
-        length (int): It's period. Default: 1
+        length (int): Its period. Default: 10
         scalar (float): How much to magnify. Default: 100
         talib (bool): If TA Lib is installed and talib is True, Returns
             the TA Lib version. Default: True

--- a/pandas_ta/performance/percent_return.py
+++ b/pandas_ta/performance/percent_return.py
@@ -19,7 +19,7 @@ def percent_return(
 
     Args:
         close (pd.Series): Series of 'close's
-        length (int): It's period. Default: 20
+        length (int): Its period. Default: 1
         cumulative (bool): If True, returns the cumulative returns.
             Default: False
         offset (int): How many periods to offset the result. Default: 0


### PR DESCRIPTION
The default length for ROC as coded is 10.

```python
length = v_pos_default(length, 10)
```

However, the documentation incorrectly states the default length as 1:
```python
    Args: 
        close (pd.Series): Series of 'close's
        length (int): It's period. Default: 1 
        scalar (float): How much to magnify. Default: 100
        talib (bool): If TA Lib is installed and talib is True, Returns
            the TA Lib version. Default: True
        offset (int): How many periods to offset the result. Default: 0
```

This PR replaces `length (int): It's period. Default: 1` with `length (int): Its period. Default: 10`

A similar issue is found with `percent_return`:

`length (int): It's period. Default: 20` is replaced with `length (int): Its period. Default: 1` since length defaults to 1, not 20, in performance/percent_return.py: `length = v_pos_default(length, 1)`