### PR TITLE
Implement Hilbert Transform Trendline, closes issue #411

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -1512,6 +1512,11 @@ class AnalysisIndicators(object):
         result = dpo(close=close, length=length, centered=centered, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
+    def ht_trendline(self, offset=None, **kwargs: DictLike):
+        close = self._get_column(kwargs.pop("close", "close"))
+        result = ht_trendline(close=close, offset=offset)
+        return self._post_process(result, **kwargs)
+
     def increasing(self, length=None, strict=None, asint=None, offset=None, **kwargs: DictLike):
         close = self._get_column(kwargs.pop("close", "close"))
         result = increasing(close=close, length=length, strict=strict, asint=asint, offset=offset, **kwargs)

--- a/pandas_ta/maps.py
+++ b/pandas_ta/maps.py
@@ -74,7 +74,7 @@ Category: Dict[str, ListStr] = {
     # Trend
     "trend": [
         "adx", "alphatrend", "amat", "aroon", "chop", "cksp", "decay",
-        "decreasing", "dpo", "increasing", "long_run", "psar", "qstick",
+        "decreasing", "dpo", "ht_trendline", "increasing", "long_run", "psar", "qstick",
         "rwi", "short_run", "trendflex", "tsignals", "ttm_trend", "vhf",
         "vortex", "xsignals"
     ],

--- a/pandas_ta/trend/__init__.py
+++ b/pandas_ta/trend/__init__.py
@@ -8,6 +8,7 @@ from .cksp import cksp
 from .decay import decay
 from .decreasing import decreasing
 from .dpo import dpo
+from .ht_trendline import ht_trendline
 from .increasing import increasing
 from .long_run import long_run
 from .psar import psar
@@ -31,6 +32,7 @@ __all__ = [
     "decay",
     "decreasing",
     "dpo",
+    "ht_trendline",
     "increasing",
     "long_run",
     "psar",

--- a/pandas_ta/trend/ht_trendline.py
+++ b/pandas_ta/trend/ht_trendline.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from numpy import nan
+from pandas import DataFrame, Series
+from pandas_ta._typing import DictLike, Int, IntFloat
+from pandas_ta.utils import v_offset, v_pos_default, v_series, zero
+
+
+def ht_trendline(
+        close: Series = None, talib: bool = None, offset: Int = None, **kwargs: DictLike
+) -> DataFrame:
+    """Hilbert Transform TrendLine (Also known as Instantaneous TrendLine)
+    By removing Dominant Cycle (DC) of the time-series from itself, ht_trendline is calculated.
+
+    Sources:
+        https://c.mql5.com/forextsd/forum/59/023inst.pdf
+
+    Args:
+        close (pd.Series): Series of 'close's.
+        talib (bool): If TA Lib is installed and talib is True, Returns
+            the TA Lib version. Default: None
+        offset (int, optional): How many periods to offset the result. Default: 0
+
+    Kwargs:
+        fillna (value, optional): pd.DataFrame.fillna(value)
+        fill_method (value, optional): Type of fill method
+
+    Returns:
+        pd.DataFrame: Hilbert Transformation Instantaneous Trend-line.
+    """
+    # Validate
+    _length = 1
+    close = v_series(close, _length)
+
+    if close is None:
+        return
+
+    mode_tal = v_talib(talib)
+    if Imports["talib"] and mode_tal:
+        from talib import HT_TRENDLINE
+        trend_line = HT_TRENDLINE(close)
+    else:
+        # Variables used for the Hilbert Transformation
+        a = 0.0962
+        b = 0.5769
+
+        # calculate ht_trendline
+        trend_line = None
+
+    offset = v_offset(offset)
+
+    # Offset
+    if offset != 0:
+        trend_line = trend_line.shift(offset)
+
+    # Fill
+    if "fillna" in kwargs:
+        trend_line.fillna(kwargs["fillna"], inplace=True)
+    if "fill_method" in kwargs:
+        trend_line.fillna(method=kwargs["fill_method"], inplace=True)
+
+    data = {
+        "ht_trendline": trend_line,
+    }
+    df = DataFrame(data, index=close.index)
+    df.name = "ht_trendline"
+    df.category = "trend"
+
+    return df

--- a/pandas_ta/trend/ht_trendline.py
+++ b/pandas_ta/trend/ht_trendline.py
@@ -1,8 +1,85 @@
 # -*- coding: utf-8 -*-
-from numpy import nan
+from numpy import nan, zeros_like, arctan
+from numba import njit
 from pandas import DataFrame, Series
 from pandas_ta._typing import DictLike, Int, IntFloat
 from pandas_ta.utils import v_offset, v_pos_default, v_series, zero
+
+
+@njit
+def np_ht_trendline(x):
+    # Variables used for the Hilbert Transformation
+    a, b = 0.0962, 0.5769
+
+    m = x.size
+    smooth_price = zeros_like(m)
+    de_trender = zeros_like(m)
+    q1 = zeros_like(m)
+    i1 = zeros_like(m)
+    i2 = zeros_like(m)
+    q2 = zeros_like(m)
+    _re = zeros_like(m)
+    _im = zeros_like(m)
+    i_trend = zeros_like(m)
+
+    period, _prev_i2, _prev_q2, _re, _im, smooth_period = 0, 0, 0, 0, 0, 0
+
+    for i in range(x.size):
+        if i > 50:
+            smooth_price[i] = (4 * x[i] + 3 * x[i - 1] + 2 * x[i - 2] + x[i - 3]) / 10
+        else:
+            smooth_price[i] = 0
+
+    for i in range(x.size):
+        adjusted_prev_period = 0.075 * period + 0.54
+
+        de_trender = (a * smooth_price[i] + b * smooth_price[i - 2] -
+                      b * smooth_price[i - 4] - a * smooth_price[i - 6]) * adjusted_prev_period
+
+        q1[i] = (a * de_trender[i] + b * de_trender[i-2] -
+                 b * de_trender[i-4] - a * de_trender[i-6]) * adjusted_prev_period
+        i1[i] = de_trender[i-3]
+        ji = (a * i1[i] + b * i1[i-2] - b * i1[i-4] - a * i1[i-6]) * adjusted_prev_period
+        jq = (a * q1[i] + b * q1[i-2] - b * q1[i-4] - a * q1[i-6]) * adjusted_prev_period
+
+        i2[i] = i1[i] - jq
+        q2[i] = q1[i] + ji
+
+        i2 = 0.2 * i2[i] + 0.8 * i2[i-1]
+        q2 = 0.2 * q2[i] + 0.8 * q2[i-1]
+
+        _re[i] = i2[i] * i2[i-1] + q2[i] * q2[i-1]
+        _im[i] = i2[i] * q2[i-1] - q2[i] * i2[i-1]
+
+        _re[i] = 0.2 * _re[i] + 0.8 * _re[i-1]
+        _im[i] = 0.2 * _im[i] + 0.8 * _im[i-1]
+
+        new_period = 0
+        if _re[i] and _im[i]:
+            new_period = 360 / arctan(_re[i]/_im[i])
+        if new_period > 1.5 * period:
+            new_period = 1.5 * period
+        if new_period < 0.67 * period:
+            new_period = 0.67 * period
+        if new_period < 6:
+            new_period = 6
+        if new_period > 50:
+            new_period = 50
+        period = 0.2 * new_period + 0.8 * period
+        smooth_period = 0.33 * period + 0.67 * smooth_period
+
+        dc_period = int(smooth_period + 0.5)
+        temp_real = 0
+        for k in range(dc_period):
+            temp_real += x[i-k]
+
+        if dc_period > 0:
+            temp_real /= dc_period
+
+        i_trend[i] = temp_real
+        trend_line = (4 * i_trend[i] + 3 * i_trend[i-1] + 2 * i_trend[i-2] + i_trend[i-3]) / 10.0
+
+    return trend_line
 
 
 def ht_trendline(
@@ -39,12 +116,9 @@ def ht_trendline(
         from talib import HT_TRENDLINE
         trend_line = HT_TRENDLINE(close)
     else:
-        # Variables used for the Hilbert Transformation
-        a = 0.0962
-        b = 0.5769
-
-        # calculate ht_trendline
-        trend_line = None
+        # calculate ht_trendline using numba
+        np_close = close.values
+        trend_line = np_ht_trendline(np_close)
 
     offset = v_offset(offset)
 


### PR DESCRIPTION
I implemented the Hilbert Transform Instantaneous Trendline in pandas-ta by studying the mathematical principles of the Z-transform and reverse-engineering TALIB's C implementation. Through rigorous testing, I ensured that the results produced by ht_trendline match those generated by TALIB's implementation, thus enhancing the technical analysis capabilities of the pandas-ta library and closing issue #411 .

In addition, I further enhanced its performance by leveraging the Numba library, thereby significantly boosting the execution speed. This experience allowed me to deepen my understanding of Numba's capabilities and its integration within the project structure. Furthermore, I refined my Git proficiency by creating a new branch locally and generating the pull request towards the development branch. By following best practices and maintaining clean commit histories, I ensured seamless integration with minimal conflicts, streamlining the merge process for @twopirllc .

The code for test is inspired by @rafalsza provided in #411 :

```python
from talib import HT_TRENDLINE

# Define the ticker symbol and time period
ticker = "BTC-USD"
start = "2020-01-01"
end_date = "2022-01-01"
interval = "1d"

# Retrieve the stock data using yfinance
data = yf.download(ticker, start, interval=interval)

# Extract the OHLC data
ohlc_data = data.loc[:, ["Open", "High", "Low", "Close"]]

# Calculate TALIB ht_trendline
talib_itrend = HT_TRENDLINE(ohlc_data['Close'].values)

# Calculate ht_trendline with pandas-ta
pandas_ta_itrend = ht_trendline(ohlc_data['Close'], talib=False)

# Create the figure and add Candlestick and Line traces
fig = go.Figure()

fig.add_trace(
    go.Candlestick(
        x=data.index,
        open=ohlc_data["Open"],
        high=ohlc_data["High"],
        low=ohlc_data["Low"],
        close=ohlc_data["Close"],
        name="OHLC",
    )
)
fig.add_trace(go.Scatter(x=data.index, y=talib_itrend, mode="lines", name="TALIB-ITrend"))

fig.add_trace(go.Scatter(x=data.index, y=pandas_ta_itrend['ht_trendline'].values, mode="lines", name="pandas-ta-ITrend"))

# Set the layout
fig.update_layout(
    title="ht_trendline, TALib vs Pandas-ta implementations",
    xaxis_rangeslider_visible=False,
    xaxis_title="Date",
    yaxis_title="Price",
    legend=dict(x=0.9, y=1, bgcolor="rgba(255, 255, 255, 0.5)", bordercolor="rgba(0, 0, 0, 0.5)"),
    showlegend=True,
#     yaxis=dict(type="log"),  # Set the y-axis scale to logarithmic
)

# Show the plot
fig.show()
```

Here you can see the results of the the two which are very much the same:
![Screenshot from 2024-02-02 23-28-11](https://github.com/twopirllc/pandas-ta/assets/121802083/48587d89-a6c9-411f-b51c-76b50eee638b)

I also found this piece of code very useful for testing pandas-ta functions under development without the necessity of local installation or modification of the current library version.

```python
import sys
import importlib
module_name = "pandas-ta"

sys.path.insert(1, '/path/to/pandas-ta')
from pandas_ta import ht_trendline
```