### PR TITLE
Zigzag indicator implementation using numba will close issue #443 and complete pr #693

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -1599,17 +1599,17 @@ class AnalysisIndicators(object):
                               trend_offset=trend_offset, trend_reset=trend_reset, offset=offset, **kwargs)
             return self._post_process(result, **kwargs)
 
-    # def zigzag(self, close=None, pivot_leg=None, price_deviation=None, retrace=None, last_extreme=None, offset=None, **kwargs: DictLike):
-    #     high = self._get_column(kwargs.pop("high", "high"))
-    #     low = self._get_column(kwargs.pop("low", "low"))
-    #     if close is not None:
-    #         close = self._get_column(kwargs.pop("close", "close"))
-    #     result = zigzag(
-    #         high=high, low=low, close=close,
-    #         pivot_leg=pivot_leg, price_deviation=price_deviation,
-    #         retrace=retrace, last_extreme=last_extreme,
-    #         offset=offset, **kwargs)
-    #     return self._post_process(result, **kwargs)
+    def zigzag(self, close=None, pivot_leg=None, price_deviation=None, retrace=None, last_extreme=None, offset=None, **kwargs: DictLike):
+        high = self._get_column(kwargs.pop("high", "high"))
+        low = self._get_column(kwargs.pop("low", "low"))
+        if close is not None:
+            close = self._get_column(kwargs.pop("close", "close"))
+        result = zigzag(
+            high=high, low=low, close=close,
+            pivot_leg=pivot_leg, price_deviation=price_deviation,
+            retrace=retrace, last_extreme=last_extreme,
+            offset=offset, **kwargs)
+        return self._post_process(result, **kwargs)
 
     # Volatility
     def aberration(self, length=None, atr_length=None, offset=None, **kwargs: DictLike):

--- a/pandas_ta/maps.py
+++ b/pandas_ta/maps.py
@@ -76,7 +76,7 @@ Category: Dict[str, ListStr] = {
         "adx", "alphatrend", "amat", "aroon", "chop", "cksp", "decay",
         "decreasing", "dpo", "increasing", "long_run", "psar", "qstick",
         "rwi", "short_run", "trendflex", "tsignals", "ttm_trend", "vhf",
-        "vortex", "xsignals"
+        "vortex", "xsignals", "zigzag"
     ],
     # Volatility
     "volatility": [

--- a/pandas_ta/trend/__init__.py
+++ b/pandas_ta/trend/__init__.py
@@ -20,6 +20,7 @@ from .ttm_trend import ttm_trend
 from .vhf import vhf
 from .vortex import vortex
 from .xsignals import xsignals
+from .zigzag import zigzag
 
 __all__ = [
     "adx",
@@ -42,5 +43,6 @@ __all__ = [
     "ttm_trend",
     "vhf",
     "vortex",
-    "xsignals"
+    "xsignals",
+    "zigzag",
 ]

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# from numpy import isnan, nan, zeros
+from numpy import isnan, nan, zeros, zeros_like, floor
 from numba import njit
-from pandas import Series
+from pandas import Series, DataFrame
 from pandas_ta._typing import DictLike, Int, IntFloat
 from pandas_ta.utils import (
     v_bool,
@@ -9,6 +9,109 @@ from pandas_ta.utils import (
     v_pos_default,
     v_series,
 )
+
+
+@njit
+def np_rolling_hl(highs, lows, window_size):
+
+    num_extremum = 0
+    candles_len = len(highs)
+    rollings_idx = zeros(candles_len)
+    rollings_types = zeros(candles_len)
+    rollings_values = zeros(candles_len)
+
+    left_side, right_side = int(floor(window_size / 2)) + 1, int(floor(window_size / 2)) + 1
+    for i in range(left_side, candles_len - right_side):  # sample_array = [*[left-window], *[center], *[right-window]]
+        lows_center = lows[i]
+        highs_center = highs[i]
+        lows_window = lows[i - left_side: i + right_side]
+        highs_window = highs[i - left_side: i + right_side]
+
+        if (lows_center <= lows_window).all():
+            rollings_idx[num_extremum] = i
+            rollings_types[num_extremum] = -1  # This -1 means it's a low swing
+            rollings_values[num_extremum] = lows_center
+            num_extremum += 1
+        if (highs_center >= highs_window).all():
+            rollings_idx[num_extremum] = i
+            rollings_types[num_extremum] = 1  # This 1 means it's a high swing
+            rollings_values[num_extremum] = highs_center
+            num_extremum += 1
+    return rollings_idx[:num_extremum], rollings_types[:num_extremum], rollings_values[:num_extremum]
+
+
+@njit
+def np_find_zigzags(rolling_idx, rolling_types, rolling_values, deviation):
+    rolling_len, num_zigzag = len(rolling_idx), 0
+
+    zigzag_idx = zeros_like(rolling_idx)
+    zigzag_types = zeros_like(rolling_types)
+    zigzag_values = zeros_like(rolling_values)
+    zigzag_dev = zeros(rolling_len)
+
+    zigzag_idx[num_zigzag] = rolling_idx[-1]
+    zigzag_types[num_zigzag] = rolling_types[-1]
+    zigzag_values[num_zigzag] = rolling_values[-1]
+    zigzag_dev[num_zigzag] = 0
+
+    for i in range(rolling_len - 2, -1, -1):
+        # last point in zigzag is bottom
+        if zigzag_types[num_zigzag] == -1:
+            if rolling_types[i] == -1:
+                if zigzag_values[num_zigzag] > rolling_values[i] and num_zigzag > 1:
+                    current_deviation = (zigzag_values[num_zigzag - 1] - rolling_values[i]) / rolling_values[i]
+                    zigzag_idx[num_zigzag] = rolling_idx[i]
+                    zigzag_types[num_zigzag] = rolling_types[i]
+                    zigzag_values[num_zigzag] = rolling_values[i]
+                    zigzag_dev[num_zigzag - 1] = 100 * current_deviation
+            else:
+                current_deviation = (rolling_values[i] - zigzag_values[num_zigzag]) / rolling_values[i]
+                if current_deviation > deviation / 100:
+                    num_zigzag += 1
+                    zigzag_idx[num_zigzag] = rolling_idx[i]
+                    zigzag_types[num_zigzag] = rolling_types[i]
+                    zigzag_values[num_zigzag] = rolling_values[i]
+                    zigzag_dev[num_zigzag - 1] = 100 * current_deviation
+
+        # last point in zigzag is peak
+        else:
+            if rolling_types[i] == 1:
+                if zigzag_values[num_zigzag] < rolling_values[i] and num_zigzag > 1:
+                    current_deviation = (rolling_values[i] - zigzag_values[num_zigzag - 1]) / rolling_values[i]
+                    zigzag_idx[num_zigzag] = rolling_idx[i]
+                    zigzag_types[num_zigzag] = rolling_types[i]
+                    zigzag_values[num_zigzag] = rolling_values[i]
+                    zigzag_dev[num_zigzag - 1] = 100 * current_deviation
+            else:
+                current_deviation = (zigzag_values[num_zigzag] - rolling_values[i]) / rolling_values[i]
+                if current_deviation > deviation / 100:
+                    num_zigzag += 1
+                    zigzag_idx[num_zigzag] = rolling_idx[i]
+                    zigzag_types[num_zigzag] = rolling_types[i]
+                    zigzag_values[num_zigzag] = rolling_values[i]
+                    zigzag_dev[num_zigzag - 1] = 100 * current_deviation
+
+    return zigzag_idx[:num_zigzag + 1], zigzag_types[:num_zigzag + 1], \
+        zigzag_values[:num_zigzag + 1], zigzag_dev[:num_zigzag + 1]
+
+
+@njit
+def map_zigzag(zigzag_idx, zigzag_types, zigzag_values, zigzag_dev, candles_num):
+    _values = zeros(candles_num)
+    _types = zeros(candles_num)
+    _dev = zeros(candles_num)
+
+    for i, index in enumerate(zigzag_idx):
+        _values[int(index)] = zigzag_values[i]
+        _types[int(index)] = zigzag_types[i]
+        _dev[int(index)] = zigzag_dev[i]
+
+    for i in range(candles_num):
+        if _types[i] == 0:
+            _values[i] = nan
+            _types[i] = nan
+            _dev[i] = nan
+    return _types, _values, _dev
 
 
 def zigzag(
@@ -51,6 +154,7 @@ def zigzag(
         pd.DataFrame: swing, and swing_type (high or low).
     """
     # Validate
+    _length = 0
     pivot_leg = _length = v_pos_default(pivot_leg, 10)
     high = v_series(high, _length + 1)
     low = v_series(low, _length + 1)
@@ -71,8 +175,11 @@ def zigzag(
 
     # Calculation
     np_high, np_low = high.values, low.values
-    highest_high = high.rolling(window=pivot_leg, center=True, min_periods=0).max()
-    lowest_low = low.rolling(window=pivot_leg, center=True, min_periods=0).min()
+    _rollings_idx, _rollings_types, _rollings_values = np_rolling_hl(highs=np_high, lows=np_low, window_size=pivot_leg)
+    _zigzags_idx, _zigzags_types, _zigzags_values, _zigzags_dev = np_find_zigzags(_rollings_idx, _rollings_types,
+                                                                                  _rollings_values,
+                                                                                  deviation=price_deviation)
+    _types, _values, _dev = map_zigzag(_zigzags_idx, _zigzags_types, _zigzags_values, _zigzags_dev, len(high))
 
     # Fix and fill working code
 
@@ -83,4 +190,14 @@ def zigzag(
     # if "fillna" in kwargs:
     # if "fill_method" in kwargs:
 
-    # Name and Category
+    _params = f"_{price_deviation}%_{pivot_leg}"
+    data = {
+        f"ZIGZAGt{_params}": _types,
+        f"ZIGZAGv{_params}": _values,
+        f"ZIGZAGd{_params}": _dev,
+    }
+    df = DataFrame(data, index=high.index)
+    df.name = f"ZIGZAG{_params}"
+    df.category = "trend"
+
+    return df

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -20,7 +20,7 @@ def np_rolling_hl(highs, lows, window_size):
     rollings_types = zeros(candles_len)
     rollings_values = zeros(candles_len)
 
-    left_side, right_side = int(floor(window_size / 2)) + 1, int(floor(window_size / 2)) + 1
+    left_side, right_side = int(floor(window_size / 2)), int(floor(window_size / 2)) + 1
     for i in range(left_side, candles_len - right_side):  # sample_array = [*[left-window], *[center], *[right-window]]
         lows_center = lows[i]
         highs_center = highs[i]
@@ -181,14 +181,21 @@ def zigzag(
                                                                                   deviation=price_deviation)
     _types, _values, _dev = map_zigzag(_zigzags_idx, _zigzags_types, _zigzags_values, _zigzags_dev, len(high))
 
-    # Fix and fill working code
-
     # Offset
-    # if offset != 0:
+    if offset != 0:
+        _types = _types.shift(offset)
+        _values = _values.shift(offset)
+        _dev = _dev.shift(offset)
 
     # Fill
-    # if "fillna" in kwargs:
-    # if "fill_method" in kwargs:
+    if "fillna" in kwargs:
+        _types.fillna(kwargs["fillna"], inplace=True)
+        _values.fillna(kwargs["fillna"], inplace=True)
+        _dev.fillna(kwargs["fillna"], inplace=True)
+    if "fill_method" in kwargs:
+        _types.fillna(method=kwargs["fill_method"], inplace=True)
+        _values.fillna(method=kwargs["fill_method"], inplace=True)
+        _dev.fillna(method=kwargs["fill_method"], inplace=True)
 
     _params = f"_{price_deviation}%_{pivot_leg}"
     data = {

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -67,6 +67,8 @@ def np_find_zigzags(rolling_idx, rolling_types, rolling_values, deviation):
             else:
                 current_deviation = (rolling_values[i] - zigzag_values[num_zigzag]) / rolling_values[i]
                 if current_deviation > deviation / 100:
+                    if zigzag_idx[num_zigzag] == rolling_idx[i]:
+                        continue
                     num_zigzag += 1
                     zigzag_idx[num_zigzag] = rolling_idx[i]
                     zigzag_types[num_zigzag] = rolling_types[i]
@@ -85,6 +87,8 @@ def np_find_zigzags(rolling_idx, rolling_types, rolling_values, deviation):
             else:
                 current_deviation = (zigzag_values[num_zigzag] - rolling_values[i]) / rolling_values[i]
                 if current_deviation > deviation / 100:
+                    if zigzag_idx[num_zigzag] == rolling_idx[i]:
+                        continue
                     num_zigzag += 1
                     zigzag_idx[num_zigzag] = rolling_idx[i]
                     zigzag_types[num_zigzag] = rolling_types[i]


### PR DESCRIPTION
Hello @twopirllc 

I'm pleased to present a new pull request for the completion of the zigzag indicator.
In this update, I've utilized Numba for implementation, as opposed to the previous approach which relied on Pandas. and compared the results with TradingView's default zigzag indicator and everything seems to be so much similar.


Below, you'll find the outcome of applying a deviation of 5% and a pivot leg of 10 to the BTCUSD daily chart:
![Screenshot from 2024-02-07 14-08-49](https://github.com/twopirllc/pandas-ta/assets/121802083/8986f09b-1456-47c2-b917-7afd3761c34d)


Compare this with the result of the new implementation under the same configuration:
![Screenshot from 2024-02-07 14-08-26](https://github.com/twopirllc/pandas-ta/assets/121802083/d9841f51-e149-479c-8250-b037fbc6579e)

In order to test it yourself, use the following code:
```python3
import sys
import importlib
import numpy as np
from numba import njit
import yfinance as yf
import plotly.graph_objects as go

sys.path.insert(1, '/path-to/pandas-ta')
from pandas_ta import zigzag

ticker = "BTC-USD"
start = "2020-01-01"
interval = "1d"

# Retrieve the stock data using yfinance
data = yf.download(ticker, start, interval=interval)

# Extract the OHLC data
ohlc_data = data.loc[:, ["Open", "High", "Low", "Close"]]

highs = ohlc_data['High']
lows = ohlc_data['Low']

df = zigzag(high=highs, low=lows, pivot_leg=10, price_deviation=5)

high_pivots = df[(df['ZIGZAGt_5%_10'].notna()) & (df['ZIGZAGt_5%_10']==1)]
low_pivots = df[(df['ZIGZAGt_5%_10'].notna()) & (df['ZIGZAGt_5%_10']==-1)]
all_pivots = df[df['ZIGZAGt_5%_10'].notna()]

fig = go.Figure()

fig.add_trace(
    go.Candlestick(
        x=data.index,
        open=ohlc_data["Open"],
        high=ohlc_data["High"],
        low=ohlc_data["Low"],
        close=ohlc_data["Close"],
        name="OHLC",
    )
)

fig.add_trace(go.Scatter(
    x=high_pivots.index, 
    y=high_pivots['ZIGZAGv_5%_10'], 
    mode="markers", 
    name="zigzag highs", 
    marker_color='rgba(0, 152, 0, .8)',
    marker_size=10,
))

fig.add_trace(go.Scatter(
    x=low_pivots.index, 
    y=low_pivots['ZIGZAGv_5%_10'], 
    mode="markers", 
    name="zigzag lows", 
    marker_color='rgba(152, 0, 0, .8)', 
    marker_size=10
))

fig.add_trace(go.Scatter(
    x=all_pivots.index, 
    y=all_pivots['ZIGZAGv_5%_10'], 
    mode="lines", 
    name="zigzag",
    line_color='rgba(0, 0, 152, 0.8)'
))

# Set the layout
fig.update_layout(
    title="ZigZag Indicator Implementations",
    xaxis_rangeslider_visible=False,
    xaxis_title="Date",
    yaxis_title="Price",
    legend=dict(x=0.9, y=1, bgcolor="rgba(255, 255, 255, 0.5)", bordercolor="rgba(0, 0, 0, 0.5)"),
    showlegend=True,
)

# Show the plot
fig.show()

```

Additionally, I believe this code snippet could prove beneficial for @AureliusMarcusHu and @KilianB in their Pandas-TA coding endeavors.