### PR TITLE
FIX RMA with adjust=False for correct EMA calc

### DIFF
--- a/pandas_ta/overlap/rma.py
+++ b/pandas_ta/overlap/rma.py
@@ -13,7 +13,7 @@ def rma(close, length=None, offset=None, **kwargs):
     if close is None: return
 
     # Calculate Result
-    rma = close.ewm(alpha=alpha, min_periods=length).mean()
+    rma = close.ewm(alpha=alpha, min_periods=length, adjust=False).mean()
 
     # Offset
     if offset != 0:


### PR DESCRIPTION
Flag `adjust=False` is missing from the WildeR's MA - RMA - so for EMA to be calculated accordingly:

[PANDAS - EWM](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.ewm.html#pandas.Series.ewm)

$ y_0 = x_0 $
$ y_t = ( 1 - \alpha )y_{t-1} + \alpha x_t $

