### PR TITLE
PVI update to match Investopedia definition and fix for issue 625

### DIFF
--- a/pandas_ta/core.py
+++ b/pandas_ta/core.py
@@ -1806,10 +1806,10 @@ class AnalysisIndicators(object):
         result = obv(close=close, volume=volume, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
-    def pvi(self, length=None, initial=None, signed=True, offset=None, **kwargs: DictLike):
+    def pvi(self, length=None, initial=None, mamode=None, offset=None, **kwargs: DictLike):
         close = self._get_column(kwargs.pop("close", "close"))
         volume = self._get_column(kwargs.pop("volume", "volume"))
-        result = pvi(close=close, volume=volume, length=length, initial=initial, signed=signed, offset=offset, **kwargs)
+        result = pvi(close=close, volume=volume, length=length, initial=initial, mamode=mamode, offset=offset, **kwargs)
         return self._post_process(result, **kwargs)
 
     def pvo(self, fast=None, slow=None, signal=None, scalar=None, offset=None, **kwargs: DictLike):

--- a/pandas_ta/volume/pvi.py
+++ b/pandas_ta/volume/pvi.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
+import pandas as pd
+import numpy as np
 from pandas import Series
 from pandas_ta._typing import DictLike, Int
+from pandas_ta.ma import ma
 from pandas_ta.momentum import roc
-from pandas_ta.utils import signed_series, v_offset, v_pos_default, v_series
-
+from pandas_ta.utils import signed_series, v_offset, v_mamode, v_pos_default, v_series
 
 def pvi(
     close: Series, volume: Series, length: Int = None, initial: Int = None,
-    offset: Int = None, **kwargs: DictLike
-) -> Series:
+    mamode: str = None, offset: Int = None, **kwargs: DictLike
+) -> pd.DataFrame:
     """Positive Volume Index (PVI)
 
     The Positive Volume Index is a cumulative indicator that uses volume
@@ -21,8 +23,9 @@ def pvi(
     Args:
         close (pd.Series): Series of 'close's
         volume (pd.Series): Series of 'volume's
-        length (int): The short period. Default: 13
-        initial (int): The short period. Default: 1000
+        length (int): The short period. Default: 255
+        initial (int): The short period. Default: 100
+        mamode (str): See ``help(ta.ma)``. Default: 'ema'
         offset (int): How many periods to offset the result. Default: 0
 
     Kwargs:
@@ -30,39 +33,58 @@ def pvi(
         fill_method (value, optional): Type of fill method
 
     Returns:
-        pd.Series: New feature generated.
+        pd.DataFrame: New DataFrame with ['close', 'volume', 'PVI_1', 'PVIs_<length>']
     """
     # Validate
-    length = v_pos_default(length, 1)
+    mamode = v_mamode(mamode, "ema")
+    length = v_pos_default(length, 255)
     close = v_series(close, length + 1)
     volume = v_series(volume, length + 1)
+    initial = v_pos_default(initial, 100)
+    offset = v_offset(offset)
 
     if close is None or volume is None:
         return
 
-    initial = v_pos_default(initial, 1000)
-    offset = v_offset(offset)
+    # Create a dataframe from the close and volume series
+    # retain index of the close series
+    df = close.to_frame('close')
+    df['volume'] = volume
+
+    df['PVI_1'] = pd.Series(dtype=float)
+    df.iloc[0, df.columns.get_loc('PVI_1')] = initial
+
+    # Get numpy arrays of the data
+    close_prices = df['close'].values
+    volumes = df['volume'].values
+    pvis = np.empty(len(df))
+
+    # Set the first value from from initial
+    pvis[0] = df.iloc[0]['PVI_1']
 
     # Calculate
-    signed_volume = signed_series(volume, 1)
-    _roc = roc(close=close, length=length)
-    pvi = _roc * signed_volume[signed_volume > 0].abs()
-    pvi.fillna(0, inplace=True)
-    pvi.iloc[0] = initial
-    pvi = pvi.cumsum()
+    for i in range(1, len(df)):
+        if volumes[i] > volumes[i-1]:
+            # PVI = Yesterday’s PVI + [[(Close – Yesterday’s Close) / Yesterday’s Close] * Yesterday’s PVI
+            pvis[i] = pvis[i-1] + (((close_prices[i] - close_prices[i-1]) / close_prices[i-1]) * pvis[i-1])
+        else:
+            # PVI = Yesterday’s PVI
+            pvis[i] = pvis[i-1]
 
-    # Offset
+    # Update the df
+    df['PVI_1'] = pvis
+    df.name = "PVI_1"
+
     if offset != 0:
-        pvi = pvi.shift(offset)
+        df['PVI_1'] = df['PVI_1'].shift(offset)
+
+    sig_series = ma(mamode, df['PVI_1'], length=length)
+    df[f'PVIs_{length}'] = sig_series
 
     # Fill
     if "fillna" in kwargs:
-        pvi.fillna(kwargs["fillna"], inplace=True)
+        df.fillna(kwargs["fillna"], inplace=True)
     if "fill_method" in kwargs:
-        pvi.fillna(method=kwargs["fill_method"], inplace=True)
+        df.fillna(method=kwargs["fill_method"], inplace=True)
 
-    # Name and Category
-    pvi.name = f"PVI_{length}"
-    pvi.category = "volume"
-
-    return pvi
+    return df

--- a/tests/test_indicator_volume.py
+++ b/tests/test_indicator_volume.py
@@ -253,7 +253,7 @@ def test_ext_nvi(df):
 
 def test_ext_pvi(df):
     df.ta.pvi(append=True)
-    assert list(df.columns) == ["close", "volume", "PVI_1", "PVIs_255"]
+    assert list(df.columns[-2:]) == ["PVI_1", "PVIs_255"]
 
 
 def test_ext_pvol(df):

--- a/tests/test_indicator_volume.py
+++ b/tests/test_indicator_volume.py
@@ -138,7 +138,7 @@ def test_obv(df):
 
 def test_pvi(df):
     result = ta.pvi(df.close, df.volume)
-    assert isinstance(result, Series)
+    assert isinstance(result, DataFrame)
     assert result.name == "PVI_1"
 
 
@@ -253,7 +253,7 @@ def test_ext_nvi(df):
 
 def test_ext_pvi(df):
     df.ta.pvi(append=True)
-    assert df.columns[-1] == "PVI_1"
+    assert list(df.columns) == ["close", "volume", "PVI_1", "PVIs_255"]
 
 
 def test_ext_pvol(df):


### PR DESCRIPTION
There are 2 PVI indicators on TradingView.

One calculates PVI using
```C
pvi := na(pvi[1]) ? initial : (change(volume) > 0 ? pvi[1] * close / close[1] : pvi[1])
```

The other uses
```C
nRes = iff(volume > volume[1], nz(nRes[1], 0) + xROC, nz(nRes[1], 0))
```

Both of them are different, and neither of them follow the logic outlined on most websites, e.g.
```
https://www.investopedia.com/terms/p/pvi.asp
https://www.kotaksecurities.com/share-market/what-is-positive-volume-index/
https://www.barchart.com/education/technical-indicators/positive_volume_index
https://www.angelone.in/knowledge-center/share-market/pvi
```

Which all show the formula as
```C
Yesterday’s PVI + [[(Close – Yesterday’s Close) / Yesterday’s Close] * Yesterday’s PVI
```

There are other definitions of the formula available online, the authors of the TV indicators may have used 

The source code referenced in issue #625 at the voice32 repo uses
```python
pvi = prev_pvi + (row[close_col] - prev_close / prev_close * prev_pvi)
```

Which is _almost_ the Investopedia version, if it had (row[close_col] - prev_close) in parentheses 


So this PR includes the following - **NOTE: This is a breaking change as the new PVI() returns a DataFrame rather than a Series**
1) Loop through arrays rather than DF rows for performance improvements
2) initial value set to 100 rather than 1000 which seems to be the norm amongst the other implementations
3) Default length parameter set to 255 to match the other implementation
4) added mamode with a default of EMA
5) returns a DataFrame rather than a Series

**Performance of the new PVI implementation** is roughly twice as fast than previous version
```sh
3275 function calls (3214 primitive calls) in 0.012 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001    0.001    0.001 datetimes.py:545(_box_func)
        1    0.001    0.001    0.011    0.011 pvi.py:77(pvi_new_vect)
        1    0.001    0.001    0.001    0.001 rolling.py:601(calc)
        1    0.001    0.001    0.001    0.001 sre_parse.py:494(_parse)
        2    0.000    0.000    0.002    0.001 indexing.py:1176(__getitem__)
  565/564    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
        6    0.000    0.000    0.002    0.000 frame.py:3971(_ixs)
        4    0.000    0.000    0.001    0.000 base.py:475(__new__)
        3    0.000    0.000    0.001    0.000 base.py:6956(insert)
        5    0.000    0.000    0.001    0.000 frame.py:4050(__getitem__)
        3    0.000    0.000    0.003    0.001 managers.py:1347(insert)
```


**Performance of the original PVI implementation** 
```sh
5088 function calls (4995 primitive calls) in 0.020 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.003    0.001    0.003    0.002 algorithms.py:1339(diff)
        1    0.001    0.001    0.001    0.001 base.py:411(_outer_indexer)
        3    0.001    0.000    0.001    0.000 datetimelike.py:388(_get_getitem_freq)
        1    0.000    0.000    0.020    0.020 <string>:1(<module>)
       12    0.000    0.000    0.002    0.000 series.py:389(__init__)
  996/979    0.000    0.000    0.001    0.000 {built-in method builtins.isinstance}
        2    0.000    0.000    0.002    0.001 frame.py:4050(__getitem__)
        1    0.000    0.000    0.018    0.018 pvi.py:169(pvi)
        2    0.000    0.000    0.004    0.002 generic.py:10612(_where)
       26    0.000    0.000    0.000    0.000 generic.py:6233(__finalize__)
        1    0.000    0.000    0.020    0.020 {built-in method builtins.exec}
       16    0.000    0.000    0.002    0.000 managers.py:317(apply)
        2    0.000    0.000    0.004    0.002 series.py:3026(diff)
  352/337    0.000    0.000    0.000    0.000 {built-in method builtins.getattr} 
```

