### PR TITLE
fixes python 3.12 syntax warning

### DIFF
--- a/pandas_ta/utils/_core.py
+++ b/pandas_ta/utils/_core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import re as re_
 from pathlib import Path
 from sys import float_info as sflt
@@ -11,7 +12,7 @@ from pandas_ta import Imports
 
 def _camelCase2Title(x: str):
     """https://stackoverflow.com/questions/5020906/python-convert-camel-case-to-space-delimited-using-regex-and-taking-acronyms-in"""
-    return re_.sub("([a-z])([A-Z])","\g<1> \g<2>", x).title()
+    return re_.sub("([a-z])([A-Z])",r"\g<1> \g<2>", x).title()
 
 
 def category_files(category: str) -> list:


### PR DESCRIPTION
Hi, I am using this project for my django app but when I upgraded to python 3.12 I was getting `SyntaxWarning: invalid escape sequence '\g'` from utils/_core.py whenever I started my server.

From 3.6-3.11 this used to be DeprecationWarning but from 3.12 onward this has been upgraded to SyntaxWarning. 
