### PR TITLE
Adding missing **kwargs in pvr indicator

### DIFF
--- a/pandas_ta/volume/pvr.py
+++ b/pandas_ta/volume/pvr.py
@@ -4,7 +4,7 @@ from numpy import nan as npNaN
 from pandas import Series
 
 
-def pvr(close, volume):
+def pvr(close, volume, **kwargs):
     """ Indicator: Price Volume Rank"""
     # Validate arguments
     close = verify_series(close)


### PR DESCRIPTION
Adding missing **kwargs in pvr volume indicator. 

This change will not impact current use, but will help future use and will prevent issues in generic code that access the functions

This MR is linked to #827 