### PR TITLE
Update squeeze_pro.py

### DIFF
--- a/pandas_ta/momentum/squeeze_pro.py
+++ b/pandas_ta/momentum/squeeze_pro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from numpy import NaN as npNaN
+from numpy import nan as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, sma


### PR DESCRIPTION
Latest numpy 2.1.1 library support nan not NaN.

when we import 
import pandas_ta as ta

it throw's error due to this NaN, when we change it to nan it runs perfectly.