### PR TITLE
Update setup.py, new pandas version 2024-09-20 conflicts with numpy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,10 @@ setup(
     package_data={
         "data": ["data/*.csv"],
     },
-    install_requires=["pandas"],
+    install_requires=[
+        "numpy==1.26.4",
+        "pandas"
+    ],
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:
     # $ pip install -e .[dev,test]


### PR DESCRIPTION
Most probably new version of pandas installs newer version of numpy and it gets an error like can't 'import NaN'. This line should freeze the older version. Should move to newer versions in the future.