### PR TITLE
Fix two issues with python and numpy upgrades

### DIFF
--- a/pandas_ta/__init__.py
+++ b/pandas_ta/__init__.py
@@ -2,22 +2,11 @@ name = "pandas_ta"
 """
 .. moduleauthor:: Kevin Johnson
 """
+import importlib.metadata
 from importlib.util import find_spec
 from pathlib import Path
-from pkg_resources import get_distribution, DistributionNotFound
 
-
-_dist = get_distribution("pandas_ta")
-try:
-    # Normalize case for Windows systems
-    here = Path(_dist.location) / __file__
-    if not here.exists():
-        # not installed, but there is another version that *is*
-        raise DistributionNotFound
-except DistributionNotFound:
-    __version__ = "Please install this project with setup.py"
-
-version = __version__ = _dist.version
+version = __version__ = importlib.metadata.version(name)
 
 Imports = {
     "alphaVantage-api": find_spec("alphaVantageAPI") is not None,

--- a/pandas_ta/momentum/squeeze_pro.py
+++ b/pandas_ta/momentum/squeeze_pro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from numpy import NaN as npNaN
+from numpy import nan as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, sma

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,10 @@ setup(
     package_data={
         "data": ["data/*.csv"],
     },
-    install_requires=["pandas"],
+    install_requires=[
+        "numpy==1.26.4",
+        "pandas"
+    ],
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:
     # $ pip install -e .[dev,test]


### PR DESCRIPTION
1. the setuptools API pks_resources is deprecated, switched to the official importlib
2. fixed case when importing nan from numpy

These two issues break when importing pandas_ta in a fresher python environment with latest python and numpy.