### PR TITLE
ZIGZAG : Backtesting safe mode boolean flag.

### DIFF
--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -91,7 +91,7 @@ def nb_find_zigzags_backtest(idx, swing, value, deviation):
 
     m = idx.size
     for i in range(m+1):
-        last_zz_value = zz_value[zigzags - (1+changes)]
+        last_zz_value = zz_value[zigzags - changes]
         current_dev = (value[i] - last_zz_value) / last_zz_value
         # Last point in zigzag is bottom
         if zz_swing[zigzags] == -1:

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -58,7 +58,7 @@ def nb_rolling_hl(np_high, np_low, window_size):
 
     return idx[:extremes], swing[:extremes], value[:extremes]
 
-@njit(cache=True)
+# @njit(cache=True)
 def nb_find_zigzags_backtest(idx, swing, value, deviation):
     """
     Calculate zigzag points using pre-calculated unfiltered pivots.
@@ -90,7 +90,7 @@ def nb_find_zigzags_backtest(idx, swing, value, deviation):
     zz_dev[zigzags] = 0
 
     m = idx.size
-    for i in range(m+1):
+    for i in range(1, m):
         last_zz_value = zz_value[zigzags - changes]
         current_dev = (value[i] - last_zz_value) / last_zz_value
         # Last point in zigzag is bottom

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -344,6 +344,10 @@ def zigzag(
     offset = v_offset(offset)
     backtest_mode = v_bool(backtest_mode, False)
 
+    if backtest_mode:
+        # Ensure signals are offset to their confirmation bar
+        offset+=int(floor(legs/2))
+
     # Calculation
     np_high, np_low = high.to_numpy(), low.to_numpy()
     hli, hls, hlv = nb_rolling_hl(np_high, np_low, legs)

--- a/pandas_ta/trend/zigzag.py
+++ b/pandas_ta/trend/zigzag.py
@@ -14,12 +14,27 @@ from pandas_ta.utils import (
 
 @njit(cache=True)
 def nb_rolling_hl(np_high, np_low, window_size):
+    """
+    Find high and low pivots.
+    Using a centered rolling window.
+    
+    Args:
+        np_high (1d np array) : High values
+        np_low (1d np array) : Low values
+        window_size (int) : Window size (will be made uneven to have equal size sides)
+
+    Returns:
+        1d np array : Detected pivot indices
+        1d np array : Detected pivot directions
+        1d np array : Detected pivot values
+    """
+
     m = np_high.size
     idx = zeros(m)
     swing = zeros(m)  # where a high = 1 and low = -1
     value = zeros(m)
 
-    extremums = 0
+    extremes = 0
     left = int(floor(window_size / 2))
     right = left + 1
     # sample_array = [*[left-window], *[center], *[right-window]]
@@ -30,22 +45,38 @@ def nb_rolling_hl(np_high, np_low, window_size):
         high_window = np_high[i - left: i + right]
 
         if (low_center <= low_window).all():
-            idx[extremums] = i
-            swing[extremums] = -1
-            value[extremums] = low_center
-            extremums += 1
+            idx[extremes] = i
+            swing[extremes] = -1
+            value[extremes] = low_center
+            extremes += 1
 
         if (high_center >= high_window).all():
-            idx[extremums] = i
-            swing[extremums] = 1
-            value[extremums] = high_center
-            extremums += 1
+            idx[extremes] = i
+            swing[extremes] = 1
+            value[extremes] = high_center
+            extremes += 1
 
-    return idx[:extremums], swing[:extremums], value[:extremums]
+    return idx[:extremes], swing[:extremes], value[:extremes]
 
 
 @njit(cache=True)
 def nb_find_zigzags(idx, swing, value, deviation):
+    """
+    Calculate zigzag points using pre-calculated unfiltered pivots.
+    
+    Args:
+        idx (1d np array) : Pivot indices
+        swing (1d np array) : Pivot swing direction -1 or 1
+        value (1d np array) : Pivot values
+        deviation (float) : Deviation percentage for reversal detection.
+
+    Returns:
+        1d np array : Zigzag point indices on original data
+        1d np array : Zigzag swing directions
+        1d np array : Zigzag point values
+        1d np array : Zigzag point deviation
+    """
+
     zz_idx = zeros_like(idx)
     zz_swing = zeros_like(swing)
     zz_value = zeros_like(value)
@@ -62,13 +93,15 @@ def nb_find_zigzags(idx, swing, value, deviation):
         # last point in zigzag is bottom
         if zz_swing[zigzags] == -1:
             if swing[i] == -1:
-                if zz_value[zigzags] > value[i] and zigzags > 1:
+                # If the pivot is lower than the last ZZ bottom, move it to the pivot
+                if value[i] < zz_value[zigzags] and zigzags > 1:
                     current_dev = (zz_value[zigzags - 1] - value[i]) / value[i]
                     zz_idx[zigzags] = idx[i]
                     zz_swing[zigzags] = swing[i]
                     zz_value[zigzags] = value[i]
                     zz_dev[zigzags - 1] = 100 * current_dev
             else:
+                # If the deviation between pivot and the last ZZ bottom is great enough create new ZZ point.
                 current_dev = (value[i] - zz_value[zigzags]) / value[i]
                 if current_dev > 0.01 * deviation:
                     if zz_idx[zigzags] == idx[i]:
@@ -82,13 +115,15 @@ def nb_find_zigzags(idx, swing, value, deviation):
         # last point in zigzag is peak
         else:
             if swing[i] == 1:
-                if zz_value[zigzags] < value[i] and zigzags > 1:
+                # If the pivot is higher than the last ZZ top, move it to the pivot
+                if value[i] > zz_value[zigzags] and zigzags > 1:
                     current_dev = (value[i] - zz_value[zigzags - 1]) / value[i]
                     zz_idx[zigzags] = idx[i]
                     zz_swing[zigzags] = swing[i]
                     zz_value[zigzags] = value[i]
                     zz_dev[zigzags - 1] = 100 * current_dev
             else:
+                # If the deviation between pivot and the last ZZ top is great enough create new ZZ point.
                 current_dev = (zz_value[zigzags] - value[i]) / value[i]
                 if current_dev > 0.01 * deviation:
                     if zz_idx[zigzags] == idx[i]:
@@ -105,6 +140,22 @@ def nb_find_zigzags(idx, swing, value, deviation):
 
 @njit(cache=True)
 def nb_map_zigzag(idx, swing, value, deviation, n):
+    """
+    Maps nb_find_zigzag results back onto the original data indices.
+
+    Args:
+        idx (1d np array): indices from nb_find_zigzag
+        swing (1d np array): swing directions from nb_find_zigzag
+        value (1d np array): values from nb_find_zigzag
+        deviation (1d np array): deviations from nb_find_zigzag
+        n (int): Length of original high low data
+
+    Returns:
+        1d np array : swing map
+        1d np array : value map
+        1d np array : deviation map
+    """    
+
     swing_map = zeros(n)
     value_map = zeros(n)
     dev_map = zeros(n)
@@ -150,11 +201,14 @@ def zigzag(
         high (pd.Series): Series of 'high's
         low (pd.Series): Series of 'low's
         close (pd.Series): Series of 'close's. Default: None
-        legs (int): Number of legs > 2. Default: 10
-        deviation (float): Price Deviation Percentage for a reversal.
+        legs (int): Pivot detection window size.
+            Pivots will be detected at the peak HL values in this window.
+            These pivots will still be filtered by the deviation criteria.
+            Minimum: 2. Default: 10
+        deviation (float): Price deviation percentage for a reversal.
             Default: 5
-        retrace (bool): Default: False
-        last_extreme (bool): Default: True
+        retrace (bool): Default: False **NOT IMPLEMENTED**
+        last_extreme (bool): Default: True **NOT IMPLEMENTED**
         offset (int): How many periods to offset the result. Default: 0
 
     Kwargs:


### PR DESCRIPTION
# [Original problem](https://github.com/twopirllc/pandas-ta/issues/871#issue-2768996500)
Currently, the zigzag indicator can't be used for back-testing purposes, as the pivot indices are placed before their actual detection would have happened.
A column that shows at what bar index the pivot was confirmed would be fantastic. The column could either have the absolute index or an offset. Along with the disregard of lag in pivot detection, there's the bigger issue of zigzag swing points moving when lower or higher pivots are detected.

# Solution
To solve the issue, I've implemented a new back testing mode into the existing zigzag implementation.  
When the new `backtest_mode` boolean flag is enabled, the function uses a modified version of the existing `nb_find_zigzags`.
This function run from front to back instead of from back to front, making it easy to track changes to existing zigzag swings.
The new function includes any raising or lowering of the swing points as new entries. Those entries should be treated as updates and not as new zigzag points.

After the zigzag points are found, an offset equal to half the pivot detection window or `floor(legs/2)` is added to the existing offset parameter. This ensures the lag of detecting pivots is accounted for.

![VoaiiXqN23](https://github.com/user-attachments/assets/0bda9873-7ab2-4151-a232-d0632d5addee)

# Other changes
Along with the main feature came some other changes:
- Improved the code readability / understandability, mostly in the form of docstrings and comment lines.
- Fixed offset not working due to the use of the non-existent `np.shift` instead of `np.roll`

# Personal ramblings
At first, this seemed like a very daunting task. But after deciphering the code, the solution did come to me pretty quickly.
I did trip up on the `nb_find_zigzags` function using a reversed approach quite a lot.
Overall, a fun and good challenge!