### PR TITLE
Fix for error when user is using Numpy 2 or above, e.g in Python 3.13.

### DIFF
--- a/pandas_ta/cycles/ebsw.py
+++ b/pandas_ta/cycles/ebsw.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from numpy import cos as npCos
 from numpy import exp as npExp
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from numpy import pi as npPi
 from numpy import sin as npSin
 from numpy import sqrt as npSqrt

--- a/pandas_ta/momentum/fisher.py
+++ b/pandas_ta/momentum/fisher.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from numpy import log as nplog
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame, Series
 from pandas_ta.overlap import hl2
 from pandas_ta.utils import get_offset, high_low_range, verify_series

--- a/pandas_ta/momentum/qqe.py
+++ b/pandas_ta/momentum/qqe.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from numpy import maximum as npMaximum
 from numpy import minimum as npMinimum
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame, Series
 
 from .rsi import rsi

--- a/pandas_ta/momentum/rsx.py
+++ b/pandas_ta/momentum/rsx.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import concat, DataFrame, Series
 from pandas_ta.utils import get_drift, get_offset, verify_series, signals
 

--- a/pandas_ta/momentum/squeeze.py
+++ b/pandas_ta/momentum/squeeze.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, linreg, sma

--- a/pandas_ta/momentum/squeeze_pro.py
+++ b/pandas_ta/momentum/squeeze_pro.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import NaN as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, sma

--- a/pandas_ta/overlap/alma.py
+++ b/pandas_ta/overlap/alma.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from numpy import exp as npExp
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import Series
 from pandas_ta.utils import get_offset, verify_series
 

--- a/pandas_ta/overlap/ema.py
+++ b/pandas_ta/overlap/ema.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas_ta import Imports
 from pandas_ta.utils import get_offset, verify_series
 

--- a/pandas_ta/overlap/hilo.py
+++ b/pandas_ta/overlap/hilo.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame, Series
 from .ma import ma
 from pandas_ta.utils import get_offset, verify_series

--- a/pandas_ta/overlap/jma.py
+++ b/pandas_ta/overlap/jma.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from numpy import average as npAverage
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from numpy import log as npLog
 from numpy import power as npPower
 from numpy import sqrt as npSqrt

--- a/pandas_ta/overlap/kama.py
+++ b/pandas_ta/overlap/kama.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import Series
 from pandas_ta.utils import get_drift, get_offset, non_zero_range, verify_series
 

--- a/pandas_ta/overlap/linreg.py
+++ b/pandas_ta/overlap/linreg.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from numpy import array as npArray
 from numpy import arctan as npAtan
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from numpy import pi as npPi
 from numpy.version import version as npVersion
 from pandas import Series

--- a/pandas_ta/overlap/supertrend.py
+++ b/pandas_ta/overlap/supertrend.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame
 from pandas_ta.overlap import hl2
 from pandas_ta.volatility import atr

--- a/pandas_ta/overlap/vidya.py
+++ b/pandas_ta/overlap/vidya.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import Series
 from pandas_ta.utils import get_drift, get_offset, verify_series
 

--- a/pandas_ta/trend/psar.py
+++ b/pandas_ta/trend/psar.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame, Series
 from pandas_ta.utils import get_offset, verify_series, zero
 

--- a/pandas_ta/trend/xsignals.py
+++ b/pandas_ta/trend/xsignals.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import DataFrame
 from .tsignals import tsignals
 from pandas_ta.utils._signals import cross_value

--- a/pandas_ta/utils/_math.py
+++ b/pandas_ta/utils/_math.py
@@ -14,7 +14,12 @@ from numpy import dot as npDot
 from numpy import fabs as npFabs
 from numpy import exp as npExp
 from numpy import log as npLog
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from numpy import ndarray as npNdArray
 from numpy import seterr
 from numpy import sqrt as npSqrt

--- a/pandas_ta/utils/_metrics.py
+++ b/pandas_ta/utils/_metrics.py
@@ -2,7 +2,12 @@
 from typing import Tuple
 
 from numpy import log as npLog
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from numpy import sqrt as npSqrt
 from pandas import Series, Timedelta
 

--- a/pandas_ta/volatility/true_range.py
+++ b/pandas_ta/volatility/true_range.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import concat
 from pandas_ta import Imports
 from pandas_ta.utils import get_drift, get_offset, non_zero_range, verify_series

--- a/pandas_ta/volume/pvr.py
+++ b/pandas_ta/volume/pvr.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from pandas_ta.utils import verify_series
-from numpy import nan as npNaN
+import numpy as np
+
+if np.__version__.startswith("2"):
+    from numpy import nan as npNaN
+else:
+    from numpy import NaN as npNaN
 from pandas import Series
 
 


### PR DESCRIPTION
from numpy import NaN as npNaN
has been replaced with
import numpy as np

if np.__version__.startswith("2"):
    from numpy import nan as npNaN
else:
    from numpy import NaN as npNaN